### PR TITLE
Document FEN handler functions

### DIFF
--- a/fen_handler.py
+++ b/fen_handler.py
@@ -17,6 +17,20 @@ fen_mapping = {
 }
 
 def fen_to_board_state(fen: str) -> List[List[Optional[str]]]:
+    """Convert a FEN string into a board representation.
+
+    Parameters
+    ----------
+    fen: str
+        Forsyth-Edwards Notation string describing the board position.
+
+    Returns
+    -------
+    List[List[Optional[str]]]
+        Nested list representing rows of the board where each element is a
+        piece name from ``fen_mapping`` or ``None`` for an empty square.
+    """
+
     board_state = []
     rows = fen.split()[0].split('/')
     for row in rows:
@@ -30,6 +44,20 @@ def fen_to_board_state(fen: str) -> List[List[Optional[str]]]:
     return board_state
 
 def load_fens_from_file(path: str) -> List[List[List[Optional[str]]]]:
+    """Read multiple FEN strings from a file.
+
+    Parameters
+    ----------
+    path: str
+        Path to a text file containing one FEN string per line.
+
+    Returns
+    -------
+    List[List[List[Optional[str]]]]
+        List of board states, each in the format returned by
+        :func:`fen_to_board_state`.
+    """
+
     positions = []
     with open(path, 'r') as f:
         for line in f:


### PR DESCRIPTION
## Summary
- clarify `fen_to_board_state` parameters and return layout
- document `load_fens_from_file` and its output structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess'; ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_689b656a5bbc83258d78bba092d89923