### PR TITLE
Clarify hanging attack logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,9 +260,9 @@ def play_games(thread_id: int, games: int, stats_out: Dict[int, Tuple[int,int,in
                 if hang:
                     sq = hang[0]
                     pc = board.piece_at(sq)
-                    sym = pc.symbol() if pc else "?"
+                    sym = pc.symbol().upper() if pc else "?"
                     logger.info(
-                        f"HANGING ATTACK: {sym} at {chess.square_name(sq)}\n" +
+                        f"HANGING ATTACK: opponent {sym} is hanging at {chess.square_name(sq)}\n" +
                         board_diagram(board, unicode=DIAGRAM_UNICODE)
                     )
 


### PR DESCRIPTION
## Summary
- Uppercase attacked piece symbol in hanging attack detection
- Log clearer message identifying the opponent's hanging piece and square

## Testing
- `pytest tests/test_evaluator.py tests/test_metrics.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_689ba273677883259fd495b8678f9bfb