### PR TITLE
feat: prioritize winning captures

### DIFF
--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -2,6 +2,14 @@ import chess
 import random
 
 CENTER_SQUARES = [chess.E4, chess.D4, chess.E5, chess.D5]
+PIECE_VALUES = {
+    chess.PAWN: 100,
+    chess.KNIGHT: 300,
+    chess.BISHOP: 300,
+    chess.ROOK: 500,
+    chess.QUEEN: 900,
+    chess.KING: 0,
+}
 
 class ChessBot:
     def __init__(self, color):
@@ -63,16 +71,23 @@ class ChessBot:
                 reasons.append("attacks king's safe square under protection (+40)")
 
         # --- стандартна логіка:
-        # 5. Захоплення підвішеної фігури
+        # 5. Захоплення фігури
         if board.is_capture(move):
-            target_sq = move.to_square
-            defenders = board.attackers(not board.turn, target_sq)
-            if not defenders:
-                score += 100
-                reasons.append("capture hanging")
-            else:
-                score += 20
-                reasons.append("capture defended")
+            target_piece = board.piece_at(move.to_square)
+            from_piece = board.piece_at(move.from_square)
+            if target_piece and from_piece:
+                gain = PIECE_VALUES[target_piece.piece_type] - PIECE_VALUES[from_piece.piece_type]
+                score += gain
+                defenders = board.attackers(not board.turn, move.to_square)
+                if not defenders:
+                    score += 100
+                    reasons.append(
+                        f"capture hanging {target_piece.symbol().upper()} (+{100 + gain})"
+                    )
+                else:
+                    reasons.append(
+                        f"capture defended {target_piece.symbol().upper()} (+{gain})"
+                    )
         # 6. Центр
         if move.to_square in CENTER_SQUARES:
             score += 30

--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -2,6 +2,7 @@ import random
 from .chess_bot import ChessBot
 from .endgame_bot import EndgameBot
 from .random_bot import RandomBot
+from .utility_bot import piece_value
 
 class DynamicBot:
     def __init__(self, color):
@@ -11,6 +12,22 @@ class DynamicBot:
         self.color = color
 
     def choose_move(self, board, debug=True):
+        # 0. Якщо можна вигідно забрати фігуру — робимо це
+        capture_moves = []
+        for move in board.legal_moves:
+            if board.is_capture(move):
+                src = board.piece_at(move.from_square)
+                tgt = board.piece_at(move.to_square)
+                if src and tgt:
+                    defenders = board.attackers(not self.color, move.to_square)
+                    if not defenders or piece_value(tgt) > piece_value(src):
+                        capture_moves.append((move, piece_value(tgt)))
+        if capture_moves:
+            move = max(capture_moves, key=lambda x: x[1])[0]
+            if debug:
+                return move, "DynamicBot: CAPTURE"
+            return move
+
         # 1. Якщо можна safe-check (шах з під захистом) — EndgameBot
         for move in board.legal_moves:
             temp = board.copy()


### PR DESCRIPTION
## Summary
- make ChessBot value material when capturing pieces
- prioritize favorable captures in DynamicBot before seeking checks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement python-chess)*

------
https://chatgpt.com/codex/tasks/task_e_689bbfa41d4c8325b0ed1c2055792ab1