### PR TITLE
Add metric-driven agent selection for DynamicBot

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -3,3 +3,10 @@ SYMBOLS = {
     "P": "♙", "R": "♖", "N": "♘", "B": "♗", "Q": "♕", "K": "♔",
     "p": "♟", "r": "♜", "n": "♞", "b": "♝", "q": "♛", "k": "♚"
 }
+
+# Thresholds for the dynamic bot.  When the material difference exceeds
+# ``MATERIAL_DIFF_THRESHOLD`` the bot switches to an aggressive style.  If the
+# king safety score drops below ``KING_SAFETY_THRESHOLD`` it prefers a
+# fortification strategy.
+MATERIAL_DIFF_THRESHOLD = 3
+KING_SAFETY_THRESHOLD = 0

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -100,6 +100,21 @@ class Evaluator:
                 score += values.get(p.piece_type, 0)
         return score
 
+    # --- Lightweight helpers used by DynamicBot ---
+    def material_diff(self, color: bool) -> int:
+        """Return material difference from ``color``'s point of view."""
+        return self.material_count(color) - self.material_count(not color)
+
+    def king_safety(self, color: bool) -> int:
+        """Simple king safety metric: defenders minus attackers."""
+        board = self.board
+        king_sq = board.king(color)
+        if king_sq is None:
+            return 0
+        attackers = len(board.attackers(not color, king_sq))
+        defenders = len(board.attackers(color, king_sq))
+        return defenders - attackers
+
 def game_incident_tags(board):
     tags = []
     material = get_material(board)


### PR DESCRIPTION
## Summary
- extend `DynamicBot` to choose agents using material advantage and king safety metrics
- expose configurable thresholds via `constants` and `BotAgent`
- provide helper evaluation methods for material and king safety

## Testing
- `pytest tests/test_evaluator.py tests/test_metrics.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_689bbea9af088325990852583d83f8b0