### PR TITLE
Add selective deepening search for checks and captures

### DIFF
--- a/chess_ai/decision_engine.py
+++ b/chess_ai/decision_engine.py
@@ -1,29 +1,61 @@
 """
-decision_engine.py — вибирає найкращий хід на основі оцінки scorer'а і features від evaluator'а.
+decision_engine.py — вибирає найкращий хід на основі пошуку з селективними розширеннями.
 """
 
-from .evaluator import Evaluator
-from .scorer import Scorer
 import random
+import chess
+
 
 class DecisionEngine:
     def __init__(self):
-        self.scorer = Scorer()
+        # Зберігаємо порожній ініціалізатор для сумісності
+        pass
 
-    def choose_best_move(self, board):
-        evaluator = Evaluator(board)
-        best_score = float('-inf')
-        best_moves = []
+    def _evaluate(self, board: chess.Board) -> int:
+        """Проста матеріальна оцінка позиції з точки зору гравця, який ходить."""
+        values = {
+            chess.PAWN: 100,
+            chess.KNIGHT: 300,
+            chess.BISHOP: 300,
+            chess.ROOK: 500,
+            chess.QUEEN: 900,
+            chess.KING: 0,
+        }
+        score = 0
+        for piece, val in values.items():
+            score += len(board.pieces(piece, board.turn)) * val
+            score -= len(board.pieces(piece, not board.turn)) * val
+        return score
+
+    def search(self, board: chess.Board, depth: int) -> int:
+        """Negamax-пошук з розширеннями по шаху та взяттю."""
+        if depth == 0 or board.is_game_over() or board.is_repetition(3):
+            return self._evaluate(board)
+
+        best = float("-inf")
+        for move in board.legal_moves:
+            extension = 1 if board.is_capture(move) or board.gives_check(move) else 0
+            board.push(move)
+            score = -self.search(board, depth - 1 + extension)
+            board.pop()
+            if score > best:
+                best = score
+        return best if best != float("-inf") else self._evaluate(board)
+
+    def choose_best_move(self, board: chess.Board):
         legal_moves = list(board.legal_moves)
+        if not legal_moves:
+            return None
+        best_score = float("-inf")
+        best_moves = []
         for move in legal_moves:
-            features = evaluator.extract_features(move)
-            score = self.scorer.score(features)
+            extension = 1 if board.is_capture(move) or board.gives_check(move) else 0
+            board.push(move)
+            score = -self.search(board, extension)
+            board.pop()
             if score > best_score:
                 best_score = score
                 best_moves = [move]
             elif score == best_score:
                 best_moves.append(move)
-        # Вибираємо випадково серед найкращих (щоб не грати одне й те саме)
-        if best_moves:
-            return random.choice(best_moves)
-        return random.choice(legal_moves)
+        return random.choice(best_moves) if best_moves else random.choice(legal_moves)

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -1,0 +1,12 @@
+import chess
+
+from chess_ai.decision_engine import DecisionEngine
+
+
+def test_capture_beats_perpetual_check():
+    """Перевіряємо, що захоплення ладді переважає серію шахів."""
+    board = chess.Board("r3n1k1/8/8/3Q4/8/8/8/5K2 w - - 0 1")
+    engine = DecisionEngine()
+    best = engine.choose_best_move(board)
+    assert best == chess.Move.from_uci("d5a8"), "Engine should capture the rook"
+


### PR DESCRIPTION
## Summary
- implement material-based negamax search with check and capture extensions
- use search in `choose_best_move` starting from depth 1
- add test ensuring rook capture is preferred over perpetual check

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_689bc43dfdd88325973dbd9831d7e2d9