### PR TITLE
Add activity and open-file features for evaluator

### DIFF
--- a/chess_ai/evaluator.py
+++ b/chess_ai/evaluator.py
@@ -25,6 +25,47 @@ class Evaluator:
             features["target_is_hanging"] = not bool(defenders)
         else:
             features["target_is_hanging"] = False
+        # --- додаткові ознаки активності та відкритих ліній ---
+
+        # Порахувати активність фігури: кількість доступних ходів після виконання
+        # цього ходу. Для цього тимчасово застосовуємо хід.
+        self.board.push(move)
+        piece_sq = move.to_square
+        piece_color = not self.board.turn  # колір, що зробив хід
+        piece = self.board.piece_at(piece_sq)
+
+        # Кількість можливих ходів (ігноруємо клітини з власними фігурами)
+        attacks = self.board.attacks(piece_sq)
+        mobility = len([sq for sq in attacks if self.board.color_at(sq) != piece_color])
+        features["active_piece"] = mobility
+
+        # Перевіряємо, чи вийшла фігура на повністю відкриту вертикаль
+        if piece and piece.piece_type in (chess.ROOK, chess.QUEEN):
+            file_idx = chess.square_file(piece_sq)
+            open_file = True
+            for rank in range(8):
+                sq = chess.square(file_idx, rank)
+                if sq != piece_sq and self.board.piece_at(sq):
+                    open_file = False
+                    break
+            features["on_open_file"] = open_file
+        else:
+            features["on_open_file"] = False
+
+        # Відкрита лінія на короля суперника
+        enemy_king = self.board.king(self.board.turn)
+        open_to_king = False
+        if piece:
+            if piece_sq in self.board.attackers(piece_color, enemy_king):
+                open_to_king = True
+            else:
+                ray = self.board.ray(piece_sq, enemy_king)
+                if ray and all(not self.board.piece_at(sq) for sq in ray):
+                    open_to_king = True
+        features["open_file_to_king"] = open_to_king
+
+        # Скасовуємо тимчасовий хід
+        self.board.pop()
 
         # Можеш легко додати більше ознак (контроль центру, шах і тп)
         return features

--- a/chess_ai/scorer.py
+++ b/chess_ai/scorer.py
@@ -27,6 +27,8 @@ class Scorer:
             "capture_defended":      40,
             "develop":               35,
             "threaten_hanging":      30,
+            "open_file_to_king":      75,
+            "active_piece":            5,
             "nothing":                1,
         }
 
@@ -50,6 +52,8 @@ class Scorer:
             base = self._score_attack_queen(pawn=True)
         elif f.get("attacks_queen"):
             base = self._score_attack_queen(pawn=False)
+        elif f.get("open_file_to_king"):
+            base = self.weights["open_file_to_king"]
         else:
             fork_s = self._score_knight_fork(f.get("knight_next_fork_pairs", []))
             if fork_s:
@@ -62,6 +66,8 @@ class Scorer:
                 base = self.weights["capture_defended"]
             elif f.get("develops_piece"):
                 base = self.weights["develop"]
+            elif f.get("active_piece"):
+                base = self.weights["active_piece"] * int(f.get("active_piece"))
             elif f.get("threaten_hanging"):
                 base = self.weights["threaten_hanging"]
             else:

--- a/tests/test_activity_features.py
+++ b/tests/test_activity_features.py
@@ -1,0 +1,18 @@
+import chess
+
+from chess_ai.evaluator import Evaluator
+
+
+def test_activity_features_present():
+    """Після ходу повинні зʼявлятися ознаки активності та відкритої лінії."""
+    board = chess.Board("4k3/8/8/8/8/8/4R3/K7 w - - 0 1")
+    evaluator = Evaluator(board)
+    move = chess.Move.from_uci("e2e7")
+
+    features = evaluator.extract_features(move)
+
+    assert "active_piece" in features
+    assert "open_file_to_king" in features
+    assert features["active_piece"] > 0
+    assert features["open_file_to_king"] is True
+


### PR DESCRIPTION
## Summary
- compute piece mobility, open-file, and king exposure features in `extract_features`
- weight new `active_piece` and `open_file_to_king` features in scorer
- test feature extraction for active pieces and open lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_689bc6829e8c8325973fbeb6013343e5