### PR TITLE
Implement shallow risk analysis for move selection

### DIFF
--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -1,6 +1,8 @@
 import chess
 import random
 
+from .risk_analyzer import RiskAnalyzer
+
 CENTER_SQUARES = [chess.E4, chess.D4, chess.E5, chess.D5]
 PIECE_VALUES = {
     chess.PAWN: 100,
@@ -14,6 +16,7 @@ PIECE_VALUES = {
 class ChessBot:
     def __init__(self, color):
         self.color = color
+        self.risk_analyzer = RiskAnalyzer()
 
     def choose_move(self, board, debug=False):
         best_score = float('-inf')
@@ -32,6 +35,9 @@ class ChessBot:
         return move
 
     def evaluate_move(self, board, move):
+        if self.risk_analyzer.is_risky(board, move):
+            return float('-inf'), "risky move"
+
         score = 0
         reasons = []
         opp_color = not self.color

--- a/chess_ai/decision_engine.py
+++ b/chess_ai/decision_engine.py
@@ -5,11 +5,13 @@ decision_engine.py — вибирає найкращий хід на основ�
 import random
 import chess
 
+from .risk_analyzer import RiskAnalyzer
+
 
 class DecisionEngine:
     def __init__(self):
         # Зберігаємо порожній ініціалізатор для сумісності
-        pass
+        self.risk_analyzer = RiskAnalyzer()
 
     def _evaluate(self, board: chess.Board) -> int:
         """Проста матеріальна оцінка позиції з точки зору гравця, який ходить."""
@@ -46,9 +48,13 @@ class DecisionEngine:
         legal_moves = list(board.legal_moves)
         if not legal_moves:
             return None
+
+        safe_moves = [m for m in legal_moves if not self.risk_analyzer.is_risky(board, m)]
+        moves_to_consider = safe_moves if safe_moves else legal_moves
+
         best_score = float("-inf")
         best_moves = []
-        for move in legal_moves:
+        for move in moves_to_consider:
             extension = 1 if board.is_capture(move) or board.gives_check(move) else 0
             board.push(move)
             score = -self.search(board, extension)
@@ -58,4 +64,4 @@ class DecisionEngine:
                 best_moves = [move]
             elif score == best_score:
                 best_moves.append(move)
-        return random.choice(best_moves) if best_moves else random.choice(legal_moves)
+        return random.choice(best_moves) if best_moves else random.choice(moves_to_consider)

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -1,0 +1,43 @@
+import chess
+
+from chess_ai.risk_analyzer import RiskAnalyzer
+from chess_ai.decision_engine import DecisionEngine
+from chess_ai.chess_bot import ChessBot
+
+
+def test_risk_analyzer_detects_hanging_piece():
+    board = chess.Board("4k3/8/8/1p6/8/8/8/3QK3 w - - 0 1")
+    analyzer = RiskAnalyzer()
+    risky_move = chess.Move.from_uci("d1a4")
+    safe_move = chess.Move.from_uci("d1e2")
+    assert analyzer.is_risky(board, risky_move)
+    assert not analyzer.is_risky(board, safe_move)
+
+
+def test_decision_engine_avoids_risky_trap(monkeypatch):
+    board = chess.Board("r2q2k1/8/8/3B2B1/8/8/8/4K3 w - - 0 1")
+    trap = chess.Move.from_uci("g5d8")
+    safe = chess.Move.from_uci("d5a8")
+
+    def fake_is_risky(self, b, m):
+        return m == trap
+
+    monkeypatch.setattr(RiskAnalyzer, "is_risky", fake_is_risky)
+    engine = DecisionEngine()
+    best = engine.choose_best_move(board)
+    assert best == safe
+
+
+def test_chess_bot_avoids_risky_trap(monkeypatch):
+    board = chess.Board("r2q2k1/8/8/3B2B1/8/8/8/4K3 w - - 0 1")
+    trap = chess.Move.from_uci("g5d8")
+    safe = chess.Move.from_uci("d5a8")
+
+    def fake_is_risky(self, b, m):
+        return m == trap
+
+    monkeypatch.setattr(RiskAnalyzer, "is_risky", fake_is_risky)
+    bot = ChessBot(chess.WHITE)
+    move = bot.choose_move(board)
+    assert move == safe
+


### PR DESCRIPTION
## Summary
- add `RiskAnalyzer` performing 1-2 ply material search to flag risky moves
- integrate risk checks into `DecisionEngine` and `ChessBot`
- test that risky traps are avoided in favour of safe wins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_689bc9d0379c8325a7d5766bd4bd0ebe