### PR TITLE
Add mobility metric to Evaluator

### DIFF
--- a/tests/test_mobility_score.py
+++ b/tests/test_mobility_score.py
@@ -1,0 +1,11 @@
+import chess
+from core.evaluator import Evaluator
+
+def test_mobility_score_recorded():
+    board = chess.Board()
+    evaluator = Evaluator(board)
+    white, black = evaluator.mobility(board)
+    metrics = evaluator.compute_final_metrics()
+    assert metrics['white_mobility'] == white
+    assert metrics['black_mobility'] == black
+    assert metrics['mobility_score'] == white - black


### PR DESCRIPTION
## Summary
- add mobility() helper to count white and black legal moves
- store and log mobility in Evaluator's metrics
- cover mobility metric with unit test

## Testing
- `pytest tests/test_mobility_score.py -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_689c4ccbfe7483259a797901c26f77b9