### PR TITLE
Improve king safety evaluation

### DIFF
--- a/core/bot_agent.py
+++ b/core/bot_agent.py
@@ -292,13 +292,13 @@ class DynamicBot:
     def _select_agent(self, board: chess.Board):
         evaluator = Evaluator(board)
         material = evaluator.material_diff(self.color)
-        safety = evaluator.king_safety(self.color)
+        king_safety_score = Evaluator.king_safety(board, self.color)
 
         choices: List[Tuple[int, Any]] = []
         if material > self.material_diff_threshold:
             choices.append((material - self.material_diff_threshold, self.aggressive))
-        if safety < self.king_safety_threshold:
-            choices.append((self.king_safety_threshold - safety, self.fortify))
+        if king_safety_score < self.king_safety_threshold:
+            choices.append((self.king_safety_threshold - king_safety_score, self.fortify))
 
         if choices:
             choices.sort(key=lambda x: x[0], reverse=True)

--- a/tests/test_king_safety.py
+++ b/tests/test_king_safety.py
@@ -1,0 +1,16 @@
+import chess
+from core.evaluator import Evaluator
+
+
+def test_king_safety_score():
+    board = chess.Board()
+    # Initial position should be neutral
+    assert Evaluator.king_safety(board, chess.WHITE) == 0
+
+    # Remove one of the shield pawns and add an attacking enemy queen
+    board.remove_piece_at(chess.F2)
+    board.remove_piece_at(chess.D8)
+    board.set_piece_at(chess.H4, chess.Piece(chess.QUEEN, chess.BLACK))
+
+    score = Evaluator.king_safety(board, chess.WHITE)
+    assert score < 0


### PR DESCRIPTION
## Summary
- expand evaluator with `king_safety` that checks pawn shield and nearby enemy attackers
- use king safety score in DynamicBot strategy selection
- add unit test for king safety scoring

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_689c75cb8d488325a3e951fd9200c790