### PR TITLE
Inject evaluator scoring into bots

### DIFF
--- a/chess_ai/aggressive_bot.py
+++ b/chess_ai/aggressive_bot.py
@@ -9,9 +9,9 @@ zero confidence.
 
 from __future__ import annotations
 
-import random
 import chess
 
+from core.evaluator import Evaluator
 from .utility_bot import piece_value
 
 
@@ -19,7 +19,7 @@ class AggressiveBot:
     def __init__(self, color: bool):
         self.color = color
 
-    def choose_move(self, board: chess.Board, debug: bool = False):
+    def choose_move(self, board: chess.Board, evaluator: Evaluator | None = None, debug: bool = False):
         """Return the move that maximises material gain.
 
         The second element of the tuple represents the material gain (our
@@ -27,25 +27,29 @@ class AggressiveBot:
         legal move is returned with confidence ``0.0``.
         """
 
+        evaluator = evaluator or Evaluator(board)
+
+        moves = list(board.legal_moves)
+        if not moves:
+            return None, 0.0
+
         best_move = None
-        best_gain = float("-inf")
-        for move in board.legal_moves:
+        best_score = float("-inf")
+        for move in moves:
             gain = 0.0
             if board.is_capture(move):
                 captured = board.piece_at(move.to_square)
                 attacker = board.piece_at(move.from_square)
                 if captured and attacker:
                     gain = piece_value(captured) - piece_value(attacker)
-            if gain > best_gain:
-                best_gain = gain
+
+            tmp = board.copy(stack=False)
+            tmp.push(move)
+            score = gain + evaluator.position_score(tmp, self.color)
+
+            if score > best_score:
+                best_score = score
                 best_move = move
 
-        if best_move is None:
-            moves = list(board.legal_moves)
-            if not moves:
-                return None, 0.0
-            best_move = random.choice(moves)
-            best_gain = 0.0
-
-        return best_move, float(best_gain)
+        return best_move, float(best_score)
 

--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -1,6 +1,7 @@
 import chess
 import random
 
+from core.evaluator import Evaluator
 from .risk_analyzer import RiskAnalyzer
 
 CENTER_SQUARES = [chess.E4, chess.D4, chess.E5, chess.D5]
@@ -18,16 +19,21 @@ class ChessBot:
         self.color = color
         self.risk_analyzer = RiskAnalyzer()
 
-    def choose_move(self, board: chess.Board, debug: bool = False):
+    def choose_move(self, board: chess.Board, evaluator: Evaluator | None = None, debug: bool = False):
         """Return the move with the highest evaluation score.
 
         The score itself serves as the confidence value.
         """
 
+        evaluator = evaluator or Evaluator(board)
+
         best_score = float("-inf")
         best_moves = []
         for move in board.legal_moves:
             score, _ = self.evaluate_move(board, move)
+            tmp = board.copy(stack=False)
+            tmp.push(move)
+            score += evaluator.position_score(tmp, self.color)
             if score > best_score:
                 best_score = score
                 best_moves = [move]

--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -3,6 +3,7 @@ from .endgame_bot import EndgameBot
 from .random_bot import RandomBot
 from .aggressive_bot import AggressiveBot
 from .fortify_bot import FortifyBot
+from core.evaluator import Evaluator
 
 
 class DynamicBot:
@@ -22,10 +23,11 @@ class DynamicBot:
             ChessBot(color),
         ]
 
-    def choose_move(self, board, debug: bool = False):
+    def choose_move(self, board, evaluator: Evaluator | None = None, debug: bool = False):
+        evaluator = evaluator or Evaluator(board)
         proposals = []
         for agent in self.agents:
-            move, conf = agent.choose_move(board)
+            move, conf = agent.choose_move(board, evaluator)
             if move is not None:
                 proposals.append((conf, move))
 

--- a/chess_ai/dynamic_bot_2.py
+++ b/chess_ai/dynamic_bot_2.py
@@ -18,21 +18,21 @@ class DynamicBot2:
         self.random_bot = RandomBot(color)
         # Можна додавати ще агентів тут
 
-    def choose_move(self, board, debug=True):
-        evaluator = Evaluator(board)
+    def choose_move(self, board, evaluator: Evaluator | None = None, debug=True):
+        evaluator = evaluator or Evaluator(board)
         features = evaluator.compute_features(self.color)
 
         if features["has_hanging_enemy"]:
-            move, reason = self.utility_bot.choose_move(board, debug=True)
+            move, reason = self.utility_bot.choose_move(board, evaluator, debug=True)
             bot_name = "UtilityBot"
         elif features["can_give_check"]:
-            move, reason = self.chess_bot.choose_move(board, debug=True)
+            move, reason = self.chess_bot.choose_move(board, evaluator, debug=True)
             bot_name = "ChessBot"
         elif self.is_endgame(board):
-            move, reason = self.endgame_bot.choose_move(board, debug=True)
+            move, reason = self.endgame_bot.choose_move(board, evaluator, debug=True)
             bot_name = "EndgameBot"
         else:
-            move, reason = self.random_bot.choose_move(board, debug=True)
+            move, reason = self.random_bot.choose_move(board, evaluator, debug=True)
             bot_name = "RandomBot"
 
         debug_info = {

--- a/chess_ai/endgame_bot.py
+++ b/chess_ai/endgame_bot.py
@@ -1,21 +1,28 @@
 import chess
 import random
 
+from core.evaluator import Evaluator
+
 class EndgameBot:
     def __init__(self, color: bool):
         self.color = color
 
-    def choose_move(self, board: chess.Board, debug: bool = False):
+    def choose_move(self, board: chess.Board, evaluator: Evaluator | None = None, debug: bool = False):
         """Choose move based on endgame heuristics.
 
         Confidence corresponds to the heuristic score of the selected move.
         """
+
+        evaluator = evaluator or Evaluator(board)
 
         best_score = float("-inf")
         best_moves = []
         enemy_king_sq = board.king(not self.color)
         for move in board.legal_moves:
             score, _ = self.evaluate_move(board, move, enemy_king_sq)
+            tmp = board.copy(stack=False)
+            tmp.push(move)
+            score += evaluator.position_score(tmp, self.color)
             if score > best_score:
                 best_score = score
                 best_moves = [move]

--- a/chess_ai/random_bot.py
+++ b/chess_ai/random_bot.py
@@ -1,15 +1,22 @@
 import random
 
+from core.evaluator import Evaluator
+
+
 class RandomBot:
     def __init__(self, color: bool):
         self.color = color
 
-    def choose_move(self, board, debug: bool = False):
-        """Return a random legal move with low confidence."""
+    def choose_move(self, board, evaluator: Evaluator | None = None, debug: bool = False):
+        """Return a random legal move adjusted by position evaluation."""
+
+        evaluator = evaluator or Evaluator(board)
 
         moves = list(board.legal_moves)
         if not moves:
             return None, 0.0
         move = random.choice(moves)
-        # Random decisions are inherently uncertain → very low confidence.
-        return move, 0.0
+        tmp = board.copy(stack=False)
+        tmp.push(move)
+        conf = evaluator.position_score(tmp, self.color)
+        return move, float(conf)

--- a/chess_ai/utility_bot.py
+++ b/chess_ai/utility_bot.py
@@ -1,16 +1,20 @@
 import chess
 
+from core.evaluator import Evaluator
+
 class UtilityBot:
     def __init__(self, color: bool):
         self.color = color
 
-    def choose_move(self, board, debug: bool = True):
+    def choose_move(self, board, evaluator: Evaluator | None = None, debug: bool = True):
         """Select a move based on simple utility heuristics.
 
         Returns a tuple of ``(move, confidence)`` where confidence is the
         heuristic score.  This bot is primarily used for feature extraction and
         testing, hence a single best move is sufficient.
         """
+
+        evaluator = evaluator or Evaluator(board)
 
         moves = list(board.legal_moves)
         best_moves = []
@@ -48,6 +52,13 @@ class UtilityBot:
                 else:
                     score = 50 + tgt_val
             # Просто хід → score = 0
+
+            if score > top_score:
+                best_moves = [move]
+                top_score = score
+            tmp = board.copy(stack=False)
+            tmp.push(move)
+            score += evaluator.position_score(tmp, self.color)
 
             if score > top_score:
                 best_moves = [move]

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -144,6 +144,30 @@ class Evaluator:
                 score -= val
         return score
 
+    def position_score(self, board: chess.Board | None = None, color: bool | None = None) -> int:
+        """Return a lightweight evaluation of ``board`` from ``color``'s perspective.
+
+        The score combines material difference and piece-square table value.  A
+        positive score favours ``color``.  If ``board`` is omitted, the
+        evaluator's own board is used.  This helper intentionally remains
+        simple—sophisticated evaluation is beyond the scope of these tests.
+        """
+
+        board = board or self.board
+        color = board.turn if color is None else color
+
+        # Temporarily switch the internal board to reuse existing helpers.
+        orig = self.board
+        self.board = board
+
+        material = self.material_diff(color)
+        psq = self.piece_square_score()
+
+        # Restore original board state.
+        self.board = orig
+
+        return material + psq if color == chess.WHITE else material - psq
+
     # --- Lightweight helpers used by DynamicBot ---
     def material_diff(self, color: bool) -> int:
         """Return material difference from ``color``'s point of view."""

--- a/tests/test_avoid_perpetual.py
+++ b/tests/test_avoid_perpetual.py
@@ -1,6 +1,7 @@
 import chess
 from chess_ai.chess_bot import ChessBot
 from chess_ai.dynamic_bot import DynamicBot
+from core.evaluator import Evaluator
 
 
 def _repetition_board():
@@ -16,12 +17,14 @@ def _repetition_board():
 def test_chess_bot_takes_rook_over_check():
     board = _repetition_board()
     bot = ChessBot(chess.WHITE)
-    move, conf = bot.choose_move(board)
+    evaluator = Evaluator(board)
+    move, conf = bot.choose_move(board, evaluator)
     assert move == chess.Move.from_uci('f7h8')
 
 
 def test_dynamic_bot_takes_rook_over_check():
     board = _repetition_board()
     bot = DynamicBot(chess.WHITE)
-    move, conf = bot.choose_move(board, debug=False)
+    evaluator = Evaluator(board)
+    move, conf = bot.choose_move(board, evaluator, debug=False)
     assert move == chess.Move.from_uci('f7h8')

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -3,6 +3,7 @@ import chess
 from chess_ai.risk_analyzer import RiskAnalyzer
 from chess_ai.decision_engine import DecisionEngine
 from chess_ai.chess_bot import ChessBot
+from core.evaluator import Evaluator
 
 
 def test_risk_analyzer_detects_hanging_piece():
@@ -38,6 +39,7 @@ def test_chess_bot_avoids_risky_trap(monkeypatch):
 
     monkeypatch.setattr(RiskAnalyzer, "is_risky", fake_is_risky)
     bot = ChessBot(chess.WHITE)
-    move, conf = bot.choose_move(board)
+    evaluator = Evaluator(board)
+    move, conf = bot.choose_move(board, evaluator)
     assert move == safe
 


### PR DESCRIPTION
## Summary
- Allow bots to receive a shared `Evaluator` and score candidate moves via `position_score`
- Adjust each bot's confidence with evaluation scores
- Aggregate evaluator-weighted confidences in `DynamicBot`

## Testing
- `pytest tests/test_avoid_perpetual.py::test_chess_bot_takes_rook_over_check -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_689c7672bc388325a1529696cc58e2c7