### PR TITLE
Boost capture gains when behind

### DIFF
--- a/chess_ai/aggressive_bot.py
+++ b/chess_ai/aggressive_bot.py
@@ -20,8 +20,10 @@ _SHARED_EVALUATOR: Evaluator | None = None
 
 
 class AggressiveBot:
-    def __init__(self, color: bool):
+    def __init__(self, color: bool, capture_gain_factor: float = 1.5):
         self.color = color
+        # Scaling applied to capture gains when we're behind in material.
+        self.capture_gain_factor = capture_gain_factor
 
     def choose_move(
         self,
@@ -67,6 +69,14 @@ class AggressiveBot:
                 attacker = board.piece_at(move.from_square)
                 if captured and attacker:
                     gain = piece_value(captured) - piece_value(attacker)
+                    # Encourage trades when behind by boosting capture gains.
+                    if context and context.material_diff < 0:
+                        gain *= self.capture_gain_factor
+                        if debug:
+                            print(
+                                f"AggressiveBot: material deficit, "
+                                f"scaled capture gain to {gain:.1f}"
+                            )
 
             tmp = board.copy(stack=False)
             tmp.push(move)

--- a/tests/test_aggressive_bot.py
+++ b/tests/test_aggressive_bot.py
@@ -1,0 +1,19 @@
+import chess
+from chess_ai.aggressive_bot import AggressiveBot
+from utils import GameContext
+
+
+class DummyEvaluator:
+    def position_score(self, board, color):
+        return 0
+
+
+def test_capture_gain_scaled_when_behind(capfd):
+    board = chess.Board("8/8/8/3r4/2P5/8/8/8 w - - 0 1")
+    ctx = GameContext(material_diff=-1, mobility=0, king_safety=0)
+    bot = AggressiveBot(chess.WHITE, capture_gain_factor=1.5)
+    move, score = bot.choose_move(board, context=ctx, evaluator=DummyEvaluator(), debug=True)
+    assert move == chess.Move.from_uci("c4d5")
+    assert score == 6.0
+    output = capfd.readouterr().out
+    assert "material deficit" in output


### PR DESCRIPTION
## Summary
- Encourage trades when behind by scaling capture gains in `AggressiveBot` with a configurable factor.
- Log the scaling when debug mode is enabled.
- Add regression test for material-deficit capture scaling.

## Testing
- `pytest tests/test_aggressive_bot.py -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a476940d488325a942e33c3a46bfd2