### PR TITLE
Skip FortifyBot when king is safe

### DIFF
--- a/tests/test_fortify_bot.py
+++ b/tests/test_fortify_bot.py
@@ -1,0 +1,42 @@
+import pytest
+import chess
+
+from chess_ai import fortify_bot
+from chess_ai.fortify_bot import FortifyBot
+from core.constants import KING_SAFETY_THRESHOLD
+from utils import GameContext
+
+
+class DummyEval:
+    def __init__(self):
+        self.calls = 0
+
+    def position_score(self, board, color):
+        self.calls += 1
+        return 0
+
+
+def test_skips_when_king_safe(capfd):
+    board = chess.Board()
+    bot = FortifyBot(chess.WHITE)
+    ctx = GameContext(material_diff=0, mobility=0, king_safety=KING_SAFETY_THRESHOLD)
+    move, score = bot.choose_move(board, context=ctx, debug=True)
+    assert move is None and score == 0.0
+    out = capfd.readouterr().out
+    assert "king safety" in out
+
+
+def test_reuses_provided_evaluator(monkeypatch):
+    board = chess.Board()
+    bot = FortifyBot(chess.WHITE)
+    ctx = GameContext(material_diff=0, mobility=0, king_safety=-1)
+    dummy = DummyEval()
+
+    def boom(*args, **kwargs):
+        raise AssertionError("Evaluator should not be created")
+
+    monkeypatch.setattr(fortify_bot, "Evaluator", boom)
+    fortify_bot._SHARED_EVALUATOR = None
+
+    move, score = bot.choose_move(board, context=ctx, evaluator=dummy)
+    assert dummy.calls > 0


### PR DESCRIPTION
## Summary
- Skip fortification when king safety meets a configurable threshold
- Reuse supplied evaluator when scoring moves
- Add tests for king-safety gating and evaluator reuse

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a4782830348325aebd042841a8a964