### PR TITLE
feat: add dynamic king evaluation

### DIFF
--- a/chess_ai/hybrid_bot/alpha_beta.py
+++ b/chess_ai/hybrid_bot/alpha_beta.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import chess
-from .evaluation import evaluate_board
+from .evaluation import evaluate_position
 
 
 INF = 10 ** 9
@@ -12,7 +12,7 @@ INF = 10 ** 9
 
 def quiescence(board: chess.Board, alpha: float, beta: float) -> float:
     """Capture-only search to resolve tactical instability."""
-    stand = evaluate_board(board)
+    stand = evaluate_position(board)
     if stand >= beta:
         return beta
     if alpha < stand:

--- a/chess_ai/hybrid_bot/evaluation.py
+++ b/chess_ai/hybrid_bot/evaluation.py
@@ -1,10 +1,11 @@
-"""Simple evaluation with dynamic king coefficient."""
+"""Material based evaluation with dynamic king value."""
 
 from __future__ import annotations
 
 import chess
 
-# Basic piece values in centipawns
+# Basic piece values in centipawns.  The king's base value is determined
+# dynamically at evaluation time.
 PIECE_VALUES = {
     chess.PAWN: 100,
     chess.KNIGHT: 320,
@@ -15,35 +16,50 @@ PIECE_VALUES = {
 }
 
 
-def dynamic_king_coeff(board: chess.Board) -> float:
-    """Return a coefficient [1,2] that grows as pieces leave the board."""
-    total = len(board.piece_map())
-    phase = total / 32.0
-    # Early game -> coeff≈1, endgame -> coeff≈2
-    return 1.0 + (1.0 - phase)
+def calculate_king_value(board: chess.Board, color: chess.Color | None = None) -> int:
+    """Return a material based value for the king.
+
+    The value is the weighted sum of the side's remaining material using the
+    formula ``p*8 + b*2 + n*2 + r*2 + q`` where ``p`` is the number of pawns,
+    ``b`` bishops, ``n`` knights, ``r`` rooks and ``q`` queens.  If the
+    opponent has no queen a small bonus is added as the king becomes slightly
+    safer.  The returned value is expressed in centipawns.
+    """
+
+    if color is None:
+        color = board.turn
+
+    p = len(board.pieces(chess.PAWN, color))
+    b = len(board.pieces(chess.BISHOP, color))
+    n = len(board.pieces(chess.KNIGHT, color))
+    r = len(board.pieces(chess.ROOK, color))
+    q = len(board.pieces(chess.QUEEN, color))
+
+    value = p * 8 + b * 2 + n * 2 + r * 2 + q
+
+    # Slightly increase the value of the king when the opponent lacks a queen.
+    if not board.pieces(chess.QUEEN, not color):
+        value += 5
+
+    return value * 100
 
 
-def _king_activity(board: chess.Board, color: bool) -> float:
-    """Simple king activity metric: closer to centre is better."""
-    sq = board.king(color)
-    if sq is None:
-        return 0.0
-    rank = chess.square_rank(sq)
-    file = chess.square_file(sq)
-    # Manhattan distance from board centre (3.5,3.5)
-    dist = abs(3.5 - rank) + abs(3.5 - file)
-    return -dist
-
-
-def evaluate_board(board: chess.Board) -> float:
+def evaluate_position(board: chess.Board) -> float:
     """Evaluate ``board`` from the side to move perspective."""
+
     score = 0.0
-    coeff = dynamic_king_coeff(board)
-    for sq, piece in board.piece_map().items():
+    wking = calculate_king_value(board, chess.WHITE)
+    bking = calculate_king_value(board, chess.BLACK)
+
+    for _, piece in board.piece_map().items():
         val = PIECE_VALUES[piece.piece_type]
         if piece.piece_type == chess.KING:
-            val += coeff * _king_activity(board, piece.color)
+            val = wking if piece.color == chess.WHITE else bking
         score += val if piece.color == chess.WHITE else -val
-    # Convert to side to move perspective
+
     return score if board.turn == chess.WHITE else -score
+
+
+# Backwards compatibility
+evaluate_board = evaluate_position
 

--- a/chess_ai/hybrid_bot/mcts.py
+++ b/chess_ai/hybrid_bot/mcts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import random
 import chess
-from .evaluation import evaluate_board
+from .evaluation import evaluate_position
 
 
 def _dirichlet(alpha: float, size: int) -> list[float]:
@@ -73,7 +73,7 @@ class BatchMCTS:
                     nb.push(m)
                     node.children[m] = Node(nb, node, p)
             # Evaluation
-            value = evaluate_board(b)
+            value = evaluate_position(b)
             # Backup
             while node is not None:
                 node.n += 1

--- a/chess_ai/hybrid_bot/orchestrator.py
+++ b/chess_ai/hybrid_bot/orchestrator.py
@@ -7,7 +7,7 @@ import chess
 
 from .alpha_beta import search as ab_search
 from .mcts import BatchMCTS
-from .evaluation import evaluate_board
+from .evaluation import evaluate_position
 
 try:  # optional R evaluation
     from .r_bridge import r_evaluate
@@ -39,7 +39,7 @@ class HybridOrchestrator:
                 return r_evaluate(board.fen())
             except Exception:
                 pass
-        return evaluate_board(board)
+        return evaluate_position(board)
 
     def choose_move(self, board: chess.Board) -> tuple[chess.Move | None, str]:
         if board.turn != self.color:


### PR DESCRIPTION
## Summary
- add material-based `calculate_king_value` for dynamic king scoring
- expose new `evaluate_position` for search algorithms
- update alpha-beta, MCTS and orchestrator to use new evaluation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68a4795448388325be07628475a296de