### PR TITLE
Share evaluator and context across agents

### DIFF
--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -49,18 +49,38 @@ class DynamicBot:
         evaluator: Evaluator | None = None,
         debug: bool = False,
     ):
-        """Gather candidate moves from each sub-bot and choose the best."""
+        """Gather candidate moves from each sub-bot and choose the best.
+
+        A single :class:`GameContext` and :class:`Evaluator` instance are
+        constructed once and shared with all sub-agents to avoid duplicated
+        work.
+        """
 
         global _SHARED_EVALUATOR
         evaluator = evaluator or _SHARED_EVALUATOR
         if evaluator is None:
             evaluator = _SHARED_EVALUATOR = Evaluator(board)
 
+        if context is None:
+            material = evaluator.material_diff(self.color)
+            white_moves, black_moves = evaluator.mobility(board)
+            mobility_score = white_moves - black_moves
+            if not self.color:
+                mobility_score = -mobility_score
+            king_safety_score = Evaluator.king_safety(board, self.color)
+            context = GameContext(
+                material_diff=material,
+                mobility=mobility_score,
+                king_safety=king_safety_score,
+            )
+
         scores: Dict[chess.Move, float] = defaultdict(float)
         debug_contrib: Dict[chess.Move, List[str]] = defaultdict(list)
 
         for agent, weight in self.agents:
-            move, conf = agent.choose_move(board, context=context, evaluator=evaluator)
+            move, conf = agent.choose_move(
+                board, context=context, evaluator=evaluator
+            )
             if move is None:
                 continue
             score = conf * weight

--- a/core/bot_agent.py
+++ b/core/bot_agent.py
@@ -304,9 +304,16 @@ class DynamicBot:
             return choices[0][1]
         return self.center
 
-    def choose_move(self, board: chess.Board, context: GameContext | None = None, debug: bool = True):
-        if context is None:
+    def choose_move(
+        self,
+        board: chess.Board,
+        context: GameContext | None = None,
+        evaluator: Evaluator | None = None,
+        debug: bool = False,
+    ):
+        if evaluator is None:
             evaluator = Evaluator(board)
+        if context is None:
             material = evaluator.material_diff(self.color)
             white_moves, black_moves = evaluator.mobility(board)
             mobility_score = white_moves - black_moves
@@ -319,7 +326,9 @@ class DynamicBot:
                 king_safety=king_safety_score,
             )
         agent = self._select_agent(context)
-        return agent.choose_move(board, context=context, debug=debug)
+        return agent.choose_move(
+            board, context=context, evaluator=evaluator, debug=debug
+        )
 
 
 # --- ФАСАД: BotAgent ---
@@ -371,4 +380,6 @@ class BotAgent:
             mobility=mobility_score,
             king_safety=king_safety_score,
         )
-        return self.impl.choose_move(board, context=context, debug=debug)
+        return self.impl.choose_move(
+            board, context=context, evaluator=evaluator, debug=debug
+        )


### PR DESCRIPTION
## Summary
- Compute shared `GameContext` and `Evaluator` for `DynamicBot`
- Allow `DynamicBot` in core to accept and forward `Evaluator`
- Reuse evaluator when invoking `BotAgent` implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a4908a80bc8325bd56a494b24e8f3f