### PR TITLE
Implement batched MCTS with neural network support

### DIFF
--- a/chess_ai/batched_mcts.py
+++ b/chess_ai/batched_mcts.py
@@ -1,0 +1,215 @@
+"""Batched Monte Carlo tree search using a neural network for policy and value.
+
+This module provides a simple MCTS implementation that evaluates a batch of
+leaf positions at once using ``net.predict_many``.  The network is expected to
+return a pair ``(policy, value)`` for each board where ``policy`` is a mapping
+from :class:`chess.Move` to prior probability and ``value`` is the position
+value from the perspective of the side to move.
+
+The search method mirrors a very small subset of AlphaZero style MCTS and is
+sufficient for unit tests and simple experimentation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+import random
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import chess
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _dirichlet(alpha: float, size: int) -> List[float]:
+    """Return a Dirichlet noise vector of ``size`` elements."""
+    samples = [random.gammavariate(alpha, 1.0) for _ in range(size)]
+    s = sum(samples)
+    if s == 0:
+        return [1.0 / size for _ in range(size)]
+    return [v / s for v in samples]
+
+
+@dataclass
+class Node:
+    """Node in the search tree."""
+
+    board: chess.Board
+    parent: Optional["Node"] = None
+    prior: float = 0.0
+    children: Dict[chess.Move, "Node"] = field(default_factory=dict)
+    n: int = 0  # visit count
+    w: float = 0.0  # total value
+
+    # ------------------------------------------------------------------
+    def q(self) -> float:
+        return self.w / self.n if self.n else 0.0
+
+    # ------------------------------------------------------------------
+    def u(self, c_puct: float) -> float:
+        if self.parent is None:
+            return self.q()
+        return self.q() + c_puct * self.prior * math.sqrt(self.parent.n) / (1 + self.n)
+
+
+# ---------------------------------------------------------------------------
+# Batched MCTS
+# ---------------------------------------------------------------------------
+
+
+class BatchedMCTS:
+    """Monte Carlo tree search that evaluates positions in batches."""
+
+    def __init__(
+        self,
+        net,
+        c_puct: float = 1.4,
+        dirichlet_alpha: float = 0.3,
+        epsilon: float = 0.25,
+    ) -> None:
+        self.net = net
+        self.c_puct = c_puct
+        self.dirichlet_alpha = dirichlet_alpha
+        self.epsilon = epsilon
+
+    # ------------------------------------------------------------------
+    def _expand(self, node: Node, board: chess.Board, add_dirichlet: bool) -> None:
+        """Expand ``node`` using network policy on ``board``."""
+        legal = list(board.legal_moves)
+        if not legal:
+            return
+        policy, _ = self.net.predict_many([board])[0]
+        priors = [policy.get(m, 0.0) for m in legal]
+        total = sum(priors)
+        if total <= 0:
+            priors = [1.0 / len(legal)] * len(legal)
+        else:
+            priors = [p / total for p in priors]
+        if add_dirichlet:
+            noise = _dirichlet(self.dirichlet_alpha, len(legal))
+            priors = [
+                (1 - self.epsilon) * p + self.epsilon * n for p, n in zip(priors, noise)
+            ]
+        for move, prior in zip(legal, priors):
+            nb = board.copy()
+            nb.push(move)
+            node.children[move] = Node(nb, node, prior)
+
+    # ------------------------------------------------------------------
+    def search_batch(
+        self,
+        root: Node,
+        n_simulations: int = 32,
+        batch_size: int = 8,
+        add_dirichlet: bool = True,
+        temperature: float = 1.0,
+    ) -> Tuple[Optional[chess.Move], Node]:
+        """Run MCTS starting from ``root``.
+
+        Returns the selected move from ``root`` and the root itself.  ``root``
+        must already contain the current board state.
+        """
+
+        board = root.board
+        legal = list(board.legal_moves)
+        if not legal:
+            return None, root
+        # Expand root on first call
+        self._expand(root, board, add_dirichlet)
+
+        sims_done = 0
+        while sims_done < n_simulations:
+            batch: List[Node] = []
+            batch_boards: List[chess.Board] = []
+            batch_paths: List[List[Node]] = []
+            # ----------------------------------------------------------
+            for _ in range(min(batch_size, n_simulations - sims_done)):
+                node = root
+                b = board.copy()
+                path = [node]
+                # Selection
+                while node.children:
+                    move, node = max(
+                        node.children.items(), key=lambda kv: kv[1].u(self.c_puct)
+                    )
+                    b.push(move)
+                    path.append(node)
+                batch.append(node)
+                batch_boards.append(b)
+                batch_paths.append(path)
+            # ----------------------------------------------------------
+            policies_values = self.net.predict_many(batch_boards)
+            for leaf, (policy, value), path, b in zip(
+                batch, policies_values, batch_paths, batch_boards
+            ):
+                # Expansion of leaf
+                if not b.is_game_over():
+                    legal_moves = list(b.legal_moves)
+                    priors = [policy.get(m, 0.0) for m in legal_moves]
+                    tot = sum(priors)
+                    if tot <= 0:
+                        priors = [1.0 / len(legal_moves)] * len(legal_moves)
+                    else:
+                        priors = [p / tot for p in priors]
+                    for m, p in zip(legal_moves, priors):
+                        nb = b.copy()
+                        nb.push(m)
+                        leaf.children[m] = Node(nb, leaf, p)
+                # Backup
+                for node in reversed(path):
+                    node.n += 1
+                    node.w += value
+                    value = -value
+            sims_done += len(batch)
+
+        # --------------------------------------------------------------
+        # Choose move from root based on visit counts
+        if temperature <= 1e-3:
+            move = max(root.children.items(), key=lambda kv: kv[1].n)[0]
+        else:
+            visits = [child.n ** (1.0 / temperature) for child in root.children.values()]
+            s = sum(visits)
+            probs = [v / s for v in visits]
+            move = random.choices(list(root.children.keys()), weights=probs, k=1)[0]
+        return move, root
+
+
+# ---------------------------------------------------------------------------
+# One-shot helper
+# ---------------------------------------------------------------------------
+
+
+def choose_move_one_shot(
+    board: chess.Board,
+    net,
+    add_dirichlet: bool = False,
+    temperature: float = 1.0,
+    dirichlet_alpha: float = 0.3,
+    epsilon: float = 0.25,
+) -> Optional[chess.Move]:
+    """Choose a move using only the network's policy for the current board."""
+    legal = list(board.legal_moves)
+    if not legal:
+        return None
+    policy, _ = net.predict_many([board])[0]
+    priors = [policy.get(m, 0.0) for m in legal]
+    tot = sum(priors)
+    if tot <= 0:
+        priors = [1.0 / len(legal)] * len(legal)
+    else:
+        priors = [p / tot for p in priors]
+    if add_dirichlet:
+        noise = _dirichlet(dirichlet_alpha, len(legal))
+        priors = [(1 - epsilon) * p + epsilon * n for p, n in zip(priors, noise)]
+    if temperature <= 1e-3:
+        idx = max(range(len(legal)), key=lambda i: priors[i])
+    else:
+        weights = [p ** (1.0 / temperature) for p in priors]
+        s = sum(weights)
+        probs = [w / s for w in weights]
+        idx = random.choices(range(len(legal)), weights=probs, k=1)[0]
+    return legal[idx]

--- a/tests/test_batched_mcts.py
+++ b/tests/test_batched_mcts.py
@@ -1,0 +1,60 @@
+import chess
+
+from chess_ai.batched_mcts import BatchedMCTS, Node, choose_move_one_shot
+
+
+class DummyNet:
+    """Simple deterministic network used for tests."""
+
+    def __init__(self):
+        self.calls = []
+
+    def predict_many(self, boards):
+        results = []
+        for b in boards:
+            self.calls.append(b.fen())
+            legal = list(b.legal_moves)
+            if legal:
+                prob = 1.0 / len(legal)
+                policy = {m: prob for m in legal}
+            else:
+                policy = {}
+            results.append((policy, 0.0))
+        return results
+
+
+def test_search_batch_calls_net_and_returns_move():
+    board = chess.Board()
+    net = DummyNet()
+    mcts = BatchedMCTS(net)
+    root = Node(board.copy())
+    move, root_after = mcts.search_batch(
+        root, n_simulations=4, batch_size=2, add_dirichlet=False, temperature=0.0
+    )
+    assert move in board.legal_moves
+    # predict_many should be called for root + two batches
+    assert len(net.calls) == 3
+    assert root_after.n == 4
+    assert sum(child.n for child in root_after.children.values()) == 4
+
+
+def test_choose_move_one_shot_uses_policy():
+    class PrefNet(DummyNet):
+        def predict_many(self, boards):
+            results = []
+            for b in boards:
+                self.calls.append(b.fen())
+                legal = list(b.legal_moves)
+                policy = {m: 0.1 / (len(legal) - 1) for m in legal}
+                for m in legal:
+                    if m.uci() == "e2e4":
+                        policy[m] = 0.9
+                        break
+                results.append((policy, 0.0))
+            return results
+
+    board = chess.Board()
+    net = PrefNet()
+    move = choose_move_one_shot(board, net, temperature=0.0)
+    assert move == chess.Move.from_uci("e2e4")
+    assert len(net.calls) == 1


### PR DESCRIPTION
## Summary
- add `BatchedMCTS` that batches leaf evaluations via `net.predict_many`
- provide `choose_move_one_shot` helper to pick a move directly from network policy
- include unit tests exercising batched search and one-shot selection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install chess -q` *(fails: Could not find a version that satisfies the requirement chess)*

------
https://chatgpt.com/codex/tasks/task_e_68a4960779208325a132ec2e553dfd6c