### PR TITLE
Forward debug flag to subagents

### DIFF
--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -79,7 +79,7 @@ class DynamicBot:
 
         for agent, weight in self.agents:
             move, conf = agent.choose_move(
-                board, context=context, evaluator=evaluator
+                board, context=context, evaluator=evaluator, debug=debug
             )
             if move is None:
                 continue


### PR DESCRIPTION
## Summary
- Ensure DynamicBot forwards the `debug` flag to each sub-agent when collecting move suggestions, preserving shared GameContext and Evaluator usage.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess -q` *(fails: Could not find a version that satisfies the requirement python-chess; ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a49531f75c83259a79c4208541e80a