### PR TITLE
Add meta-agent weighting tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Chess AI
+
+## Meta Mode
+
+The project includes a *meta* mode implemented by `DynamicBot`, which acts as an
+aggregator for multiple sub-bots. Each sub-bot contributes a move suggestion
+along with a confidence value.  The meta-agent multiplies each confidence by the
+assigned weight and sums the results per move.
+
+### Weight format
+
+Weights are provided as a dictionary mapping agent names to floating point
+values when creating `DynamicBot`:
+
+```python
+from chess_ai.dynamic_bot import DynamicBot
+import chess
+
+bot = DynamicBot(chess.WHITE, weights={"aggressive": 1.5, "fortify": 0.5})
+```
+
+### Example usage
+
+```python
+board = chess.Board()
+move, score = bot.choose_move(board, debug=True)
+```
+
+The chosen move is the one with the highest total weighted confidence.
+

--- a/tests/test_dynamic_bot.py
+++ b/tests/test_dynamic_bot.py
@@ -1,0 +1,25 @@
+import chess
+import pytest
+
+from chess_ai.dynamic_bot import DynamicBot
+
+
+def test_meta_agent_combines_weighted_subbots():
+    board = chess.Board()
+    bot = DynamicBot(chess.WHITE)
+    bot.agents = []
+
+    class BotA:
+        def choose_move(self, board, context=None, evaluator=None):
+            return chess.Move.from_uci("e2e4"), 0.6
+
+    class BotB:
+        def choose_move(self, board, context=None, evaluator=None):
+            return chess.Move.from_uci("e2e4"), 0.4
+
+    bot.register_agent(BotA(), weight=2.0)
+    bot.register_agent(BotB(), weight=0.5)
+
+    move, score = bot.choose_move(board)
+    assert move == chess.Move.from_uci("e2e4")
+    assert score == pytest.approx(0.6 * 2.0 + 0.4 * 0.5)

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -15,6 +15,15 @@ def test_risk_analyzer_detects_hanging_piece():
     assert not analyzer.is_risky(board, safe_move)
 
 
+def test_risk_analyzer_handles_hanging_and_safe_moves():
+    board = chess.Board("r3k2r/2n5/8/8/8/8/8/R3K2R w KQkq - 0 1")
+    analyzer = RiskAnalyzer()
+    risky = chess.Move.from_uci("a1a8")
+    safe = chess.Move.from_uci("h1h8")
+    assert analyzer.is_risky(board, risky)
+    assert not analyzer.is_risky(board, safe)
+
+
 def test_alpha_beta_prunes(monkeypatch):
     board = chess.Board()
     analyzer = RiskAnalyzer()


### PR DESCRIPTION
## Summary
- test meta-agent combines weighted sub-bot outputs
- test RiskAnalyzer flags hanging move while allowing safe move
- document meta mode weights and usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5664a54832598c64ed6caee36ec