### PR TITLE
Add R-based board evaluation bridge

### DIFF
--- a/chess_ai/hybrid_bot/eval_position_complex.R
+++ b/chess_ai/hybrid_bot/eval_position_complex.R
@@ -1,0 +1,8 @@
+eval_position_complex <- function(fen) {
+  # Simple evaluation: difference in number of pieces
+  # between white (uppercase) and black (lowercase).
+  board_str <- strsplit(strsplit(fen, " ")[[1]][1], "")[[1]]
+  whites <- sum(board_str %in% LETTERS)
+  blacks <- sum(board_str %in% letters)
+  return(whites - blacks)
+}

--- a/chess_ai/hybrid_bot/r_bridge.py
+++ b/chess_ai/hybrid_bot/r_bridge.py
@@ -1,6 +1,10 @@
-"""Bridge to R-based evaluation via rpy2."""
+"""Bridge to R-based board evaluation via :mod:`rpy2`."""
 
 from __future__ import annotations
+
+from pathlib import Path
+
+import chess
 
 try:  # pragma: no cover - optional dependency
     from rpy2 import robjects
@@ -8,17 +12,38 @@ except Exception:  # rpy2 may be missing in lightweight environments
     robjects = None  # type: ignore
 
 
-def r_evaluate(fen: str) -> float:
-    """Evaluate position ``fen`` using an R function named ``r_eval``.
+_FUNC_NAME = "eval_position_complex"
+_loaded = False
 
-    The R environment must define ``r_eval`` that accepts a FEN string and
-    returns a single numeric value.  If :mod:`rpy2` or the function is not
-    available, ``RuntimeError`` is raised.
-    """
+
+def _ensure_loaded() -> None:
+    """Load the R evaluation function if available."""
+    global _loaded
+    if _loaded:
+        return
     if robjects is None:
         raise RuntimeError("rpy2 is not installed")
-    if "r_eval" not in robjects.globalenv:
-        raise RuntimeError("R function 'r_eval' not found in global env")
-    r_func = robjects.globalenv["r_eval"]
-    return float(r_func(fen)[0])
+    script = Path(__file__).with_name(f"{_FUNC_NAME}.R")
+    robjects.r["source"](str(script))
+    if _FUNC_NAME not in robjects.globalenv:
+        raise RuntimeError(f"R function '{_FUNC_NAME}' not found after sourcing")
+    _loaded = True
+
+
+def eval_board(board: chess.Board) -> float:
+    """Return evaluation score for ``board`` using R's ``eval_position_complex``.
+
+    The function sources the accompanying R script and calls the R function,
+    returning its numeric result.  ``RuntimeError`` is raised if :mod:`rpy2` or
+    the R function is unavailable.
+    """
+    _ensure_loaded()
+    r_func = robjects.globalenv[_FUNC_NAME]
+    return float(r_func(board.fen())[0])
+
+
+def r_evaluate(fen: str) -> float:
+    """Backward compatible FEN-based wrapper around :func:`eval_board`."""
+    board = chess.Board(fen)
+    return eval_board(board)
 

--- a/tests/test_r_bridge.py
+++ b/tests/test_r_bridge.py
@@ -1,0 +1,12 @@
+import chess
+import pytest
+
+rpy2 = pytest.importorskip("rpy2")
+
+from chess_ai.hybrid_bot.r_bridge import eval_board
+
+
+def test_eval_board_returns_float():
+    board = chess.Board()
+    score = eval_board(board)
+    assert isinstance(score, float)


### PR DESCRIPTION
## Summary
- bridge to R evaluation using rpy2 in `eval_board`
- add simple R script `eval_position_complex.R`
- test ensures `eval_board` returns a float (skipped if rpy2 missing)

## Testing
- `pip install rpy2` *(fails: Could not find a version that satisfies the requirement rpy2)*
- `pip install chess` *(fails: Could not find a version that satisfies the requirement chess)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a4a5d75cfc8325a309d1e3e2ee286e