### PR TITLE
feat: add top-k MCTS/AB orchestrator

### DIFF
--- a/chess_ai/hybrid_bot/orchestrator.py
+++ b/chess_ai/hybrid_bot/orchestrator.py
@@ -1,8 +1,18 @@
-"""Hybrid orchestrator that mixes MCTS and alpha-beta search."""
+"""Hybrid orchestrator blending MCTS and alpha-beta search.
+
+This module defines :class:`HybridOrchestrator` which performs a Monte
+Carlo tree search to gather the top-K candidate moves.  Each candidate is
+validated by running an alpha-beta search and by invoking the optional
+R-based evaluator.  The normalised scores from the MCTS and alpha-beta
+steps are combined using a λ-mix to determine the final move.  Diagnostic
+information is returned to aid visualisation.
+"""
 
 from __future__ import annotations
 
-import random
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Any
+
 import chess
 
 from .alpha_beta import search as ab_search
@@ -10,58 +20,112 @@ from .mcts import BatchMCTS
 from .evaluation import evaluate_position
 
 try:  # optional R evaluation
-    from .r_bridge import r_evaluate
-except Exception:  # pragma: no cover
-    r_evaluate = None  # type: ignore
+    from .r_bridge import eval_board
+except Exception:  # pragma: no cover - rpy2 may be absent
+    eval_board = None  # type: ignore
+
+
+@dataclass
+class _Candidate:
+    move: chess.Move
+    mcts: float
+    ab: float
+    r: float
+    mcts_norm: float = 0.0
+    ab_norm: float = 0.0
+    mixed: float = 0.0
 
 
 class HybridOrchestrator:
-    """Combine two search techniques and choose between their suggestions."""
+    """Select moves by mixing MCTS and alpha-beta evaluations."""
 
     def __init__(
         self,
         color: bool,
         ab_depth: int = 3,
         mcts_simulations: int = 64,
-        mix_prob: float = 0.5,
-        use_r_eval: bool = False,
+        top_k: int = 3,
+        lam: float = 0.5,
     ) -> None:
         self.color = color
         self.ab_depth = ab_depth
         self.mcts_simulations = mcts_simulations
-        self.mix_prob = mix_prob
+        self.top_k = top_k
+        self.lam = lam
         self.mcts = BatchMCTS()
-        self.use_r_eval = use_r_eval and r_evaluate is not None
 
-    def _evaluate(self, board: chess.Board) -> float:
-        if self.use_r_eval:
+    # ------------------------------------------------------------------
+    #  Helpers
+    # ------------------------------------------------------------------
+    def _r_eval(self, board: chess.Board) -> float:
+        """Evaluate ``board`` using R evaluator if available."""
+        if eval_board is not None:
             try:
-                return r_evaluate(board.fen())
+                return eval_board(board)
             except Exception:
                 pass
         return evaluate_position(board)
 
-    def choose_move(self, board: chess.Board) -> tuple[chess.Move | None, str]:
+    # ------------------------------------------------------------------
+    #  Public API
+    # ------------------------------------------------------------------
+    def choose_move(self, board: chess.Board) -> Tuple[chess.Move | None, Dict[str, Any]]:
+        """Return the final move and diagnostic information."""
         if board.turn != self.color:
-            return None, "not my turn"
-        # Compute candidate moves
-        mcts_move, _ = self.mcts.search(board, n_simulations=self.mcts_simulations)
-        ab_score, ab_move = ab_search(board, self.ab_depth)
-        candidates: list[tuple[chess.Move | None, float, str]] = []
-        if mcts_move is not None:
-            b = board.copy()
-            b.push(mcts_move)
-            candidates.append((mcts_move, self._evaluate(b), "MCTS"))
-        if ab_move is not None:
-            b = board.copy()
-            b.push(ab_move)
-            candidates.append((ab_move, self._evaluate(b), "AB"))
-        if not candidates:
-            return None, "no moves"
-        # With probability mix_prob choose higher eval, otherwise random between them
-        if random.random() < self.mix_prob and len(candidates) >= 2:
-            move, _, tag = max(candidates, key=lambda x: x[1])
-            return move, f"HYBRID({tag})"
-        move, _, tag = random.choice(candidates)
-        return move, f"HYBRID({tag})"
+            return None, {"candidates": [], "chosen": None, "mcts_first": None}
 
+        # Perform MCTS and gather top-K candidates by visit count
+        _, root = self.mcts.search(board, n_simulations=self.mcts_simulations)
+        children = sorted(root.children.items(), key=lambda kv: kv[1].n, reverse=True)
+        if not children:
+            return None, {"candidates": [], "chosen": None, "mcts_first": None}
+
+        candidates: List[_Candidate] = []
+        for move, node in children[: self.top_k]:
+            b = board.copy()
+            b.push(move)
+            depth = max(1, self.ab_depth - 1)
+            ab_val, _ = ab_search(b, depth)
+            ab_val = -ab_val  # convert to our perspective
+            r_val = self._r_eval(b)
+            if b.turn != self.color:
+                r_val = -r_val
+            ab_score = (ab_val + r_val) / 2
+            candidates.append(_Candidate(move, node.q(), ab_score, r_val))
+
+        # Normalise scores
+        def _norm(vals: List[float]) -> List[float]:
+            mn, mx = min(vals), max(vals)
+            if abs(mx - mn) < 1e-9:
+                return [0.5 for _ in vals]
+            return [(v - mn) / (mx - mn) for v in vals]
+
+        mcts_norms = _norm([c.mcts for c in candidates])
+        ab_norms = _norm([c.ab for c in candidates])
+        for cand, m_n, a_n in zip(candidates, mcts_norms, ab_norms):
+            cand.mcts_norm = m_n
+            cand.ab_norm = a_n
+            cand.mixed = self.lam * m_n + (1 - self.lam) * a_n
+
+        chosen = max(candidates, key=lambda c: c.mixed)
+        mcts_first = max(candidates, key=lambda c: c.mcts)
+        diag = {
+            "candidates": [
+                {
+                    "move": c.move.uci(),
+                    "mcts": c.mcts,
+                    "ab": c.ab,
+                    "r": c.r,
+                    "mcts_norm": c.mcts_norm,
+                    "ab_norm": c.ab_norm,
+                    "mixed": c.mixed,
+                }
+                for c in candidates
+            ],
+            "chosen": chosen.move.uci(),
+            "mcts_first": mcts_first.move.uci(),
+        }
+        return chosen.move, diag
+
+
+__all__ = ["HybridOrchestrator"]


### PR DESCRIPTION
## Summary
- expand HybridOrchestrator to rank top-K moves from MCTS
- validate candidates via alpha-beta search and optional R evaluation
- mix normalised MCTS and AB scores with lambda weighting and return diagnostics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install chess` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1764a8c8325b53004ca364a4d49