### PR TITLE
Use game context in EndgameBot heuristics

### DIFF
--- a/tests/test_endgame_bot.py
+++ b/tests/test_endgame_bot.py
@@ -1,0 +1,29 @@
+import random
+import chess
+
+from chess_ai.endgame_bot import EndgameBot
+from utils import GameContext
+
+
+def test_check_bonus_scaled_by_material():
+    board = chess.Board()
+    bot = EndgameBot(chess.WHITE)
+    move = chess.Move.from_uci("d1h5")  # Qh5+
+    enemy_king = board.king(chess.BLACK)
+
+    random.seed(0)
+    base_score, _ = bot.evaluate_move(
+        board,
+        move,
+        enemy_king,
+        GameContext(material_diff=0, mobility=0, king_safety=0),
+    )
+    random.seed(0)
+    ahead_score, _ = bot.evaluate_move(
+        board,
+        move,
+        enemy_king,
+        GameContext(material_diff=2, mobility=0, king_safety=0),
+    )
+
+    assert ahead_score > base_score


### PR DESCRIPTION
## Summary
- Allow EndgameBot.choose_move to accept shared context and evaluator
- Adjust check bonus using `material_diff` and `king_safety`
- Add regression test for material-aware check scoring

## Testing
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement python-chess)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b1c3b40483259ce796b1abc95271