### PR TITLE
Add orchestrator diagnostics plotting

### DIFF
--- a/chess_ai/hybrid_bot/viz.py
+++ b/chess_ai/hybrid_bot/viz.py
@@ -2,23 +2,73 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Any, Mapping, Sequence, Tuple
 
 
-def plot_orchestrator_diag(stats: Mapping[str, float]):
-    """Plot simple diagnostic bars using :mod:`matplotlib`.
+def plot_orchestrator_diag(
+    diag: Mapping[str, Any],
+    title: str | None = None,
+    save_path: str | None = None,
+) -> Tuple["Figure", Sequence["Axes"]]:
+    """Plot diagnostic information returned by :class:`HybridOrchestrator`.
 
-    ``stats`` maps labels to numeric scores.  The function returns the created
-    ``(fig, ax)`` tuple so callers may further adjust or save the figure.
-    ``matplotlib`` is imported lazily to keep the module lightweight.
+    Parameters
+    ----------
+    diag:
+        Dictionary produced by :meth:`HybridOrchestrator.choose_move` containing
+        a ``"candidates"`` list and ``"chosen"`` move.
+    title:
+        Optional figure title.
+    save_path:
+        If provided, the figure is saved to this path using
+        :func:`matplotlib.figure.Figure.savefig`.
+
+    Returns
+    -------
+    ``(fig, axes)``
+        Created matplotlib figure and axes.
     """
+
     import matplotlib.pyplot as plt  # local import to avoid heavy dependency
 
-    labels = list(stats.keys())
-    values = list(stats.values())
-    fig, ax = plt.subplots()
-    ax.bar(labels, values)
-    ax.set_ylabel("score")
-    ax.set_title("Hybrid orchestrator diagnostics")
-    return fig, ax
+    candidates = diag.get("candidates", [])
+    moves = [c.get("move", "?") for c in candidates]
+    mcts_vals = [c.get("mcts", 0.0) for c in candidates]
+    ab_vals = [c.get("ab", 0.0) for c in candidates]
+    weights = [c.get("mixed", 0.0) for c in candidates]
+    chosen = diag.get("chosen")
+
+    # Highlight the chosen move.
+    colors = ["tab:orange" if m == chosen else "tab:blue" for m in moves]
+
+    x = list(range(len(moves)))
+
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+
+    axes[0].bar(x, mcts_vals, color=colors)
+    axes[0].set_title("MCTS visits")
+    axes[0].set_ylabel("value")
+
+    axes[1].bar(x, ab_vals, color=colors)
+    axes[1].set_title("AB score")
+
+    axes[2].bar(x, weights, color=colors)
+    axes[2].set_title("Normalised weight")
+
+    for ax in axes:
+        ax.set_xticks(x)
+        ax.set_xticklabels(moves, rotation=45)
+
+    if title:
+        fig.suptitle(title)
+
+    fig.tight_layout()
+
+    if save_path is not None:
+        fig.savefig(save_path, bbox_inches="tight")
+
+    return fig, axes
+
+
+__all__ = ["plot_orchestrator_diag"]
 


### PR DESCRIPTION
## Summary
- add matplotlib visualisation for hybrid orchestrator diagnostics
- show MCTS visits, alpha-beta scores and mixed weights with chosen move highlighted

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement python-chess (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7af33a08325923a11b25ec0395e