### PR TITLE
Implement run loader utility with validation and tests

### DIFF
--- a/tests/test_load_runs.py
+++ b/tests/test_load_runs.py
@@ -1,0 +1,47 @@
+import json
+import os
+import tempfile
+from utils.load_runs import load_runs
+
+
+def test_load_runs_valid():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sample = {
+            "moves": ["e4"],
+            "fens": ["startpos"],
+            "modules_w": ["module1"],
+            "modules_b": ["module2"],
+        }
+        with open(os.path.join(tmpdir, "game1.json"), "w", encoding="utf-8") as f:
+            json.dump(sample, f)
+
+        runs = load_runs(tmpdir)
+        assert len(runs) == 1
+        run = runs[0]
+        assert run["game_id"] == "game1"
+        assert run["moves"] == sample["moves"]
+        assert run["fens"] == sample["fens"]
+        assert run["modules_w"] == sample["modules_w"]
+        assert run["modules_b"] == sample["modules_b"]
+
+
+def test_load_runs_missing_key():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        incomplete = {
+            "moves": [],
+            "fens": [],
+            "modules_w": [],
+        }
+        with open(os.path.join(tmpdir, "game2.json"), "w", encoding="utf-8") as f:
+            json.dump(incomplete, f)
+
+        try:
+            load_runs(tmpdir)
+            assert False, "Expected ValueError due to missing keys"
+        except ValueError as e:
+            assert "modules_b" in str(e)
+
+
+if __name__ == "__main__":
+    test_load_runs_valid()
+    test_load_runs_missing_key()

--- a/utils/load_runs.py
+++ b/utils/load_runs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+REQUIRED_KEYS = {"moves", "fens", "modules_w", "modules_b"}
+
+
+def load_runs(path: str) -> List[Dict[str, Any]]:
+    """Load all run JSON files from *path*.
+
+    Each JSON file must contain the keys defined in :data:`REQUIRED_KEYS`.
+    The returned list contains dictionaries with those values plus a
+    ``game_id`` derived from the file name (without extension).
+
+    Parameters
+    ----------
+    path:
+        Directory that holds run ``.json`` files.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of run objects with ``game_id`` and required fields.
+
+    Raises
+    ------
+    ValueError
+        If a JSON file is missing any required keys.
+    """
+    runs: List[Dict[str, Any]] = []
+    base_path = Path(path)
+
+    for file in sorted(base_path.glob("*.json")):
+        with file.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        missing = REQUIRED_KEYS - data.keys()
+        if missing:
+            raise ValueError(f"Missing keys in {file.name}: {', '.join(sorted(missing))}")
+
+        runs.append(
+            {
+                "game_id": file.stem,
+                "moves": data["moves"],
+                "fens": data["fens"],
+                "modules_w": data["modules_w"],
+                "modules_b": data["modules_b"],
+            }
+        )
+
+    return runs


### PR DESCRIPTION
## Summary
- add `utils.load_runs.load_runs` to parse saved run JSON files, validating required keys and returning structured results
- create tests verifying proper loading and error handling for missing keys

## Testing
- `pytest tests/test_load_runs.py`
- `pytest tests/test_load_runs.py tests/test_evaluator.py tests/test_metrics.py` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install chess` *(fails: Could not find a version that satisfies the requirement chess)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b97a98908325aec82d14e5ef988d