### PR TITLE
test: pass shared evaluator and context

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import chess
+import pytest
+
+from core.evaluator import Evaluator
+from utils import GameContext
+
+
+@pytest.fixture(scope="module")
+def evaluator():
+    """Shared evaluator instance reused across tests."""
+    return Evaluator(chess.Board())
+
+
+@pytest.fixture
+def context():
+    """Minimal game context with neutral metrics."""
+    return GameContext(material_diff=0, mobility=0, king_safety=0)

--- a/tests/test_aggressive_bot.py
+++ b/tests/test_aggressive_bot.py
@@ -3,17 +3,18 @@ from chess_ai.aggressive_bot import AggressiveBot
 from utils import GameContext
 
 
-class DummyEvaluator:
-    def position_score(self, board, color):
-        return 0
-
-
-def test_capture_gain_scaled_when_behind(capfd):
+def test_capture_gain_scaled_when_behind(capfd, evaluator):
     board = chess.Board("8/8/8/3r4/2P5/8/8/8 w - - 0 1")
+    evaluator.board = board
     ctx = GameContext(material_diff=-1, mobility=0, king_safety=0)
     bot = AggressiveBot(chess.WHITE, capture_gain_factor=1.5)
-    move, score = bot.choose_move(board, context=ctx, evaluator=DummyEvaluator(), debug=True)
+    move, score = bot.choose_move(board, context=ctx, evaluator=evaluator, debug=True)
     assert move == chess.Move.from_uci("c4d5")
-    assert score == 6.0
+
+    tmp = board.copy(stack=False)
+    tmp.push(chess.Move.from_uci("c4d5"))
+    expected = 6 + evaluator.position_score(tmp, chess.WHITE)
+    assert score == expected
+
     output = capfd.readouterr().out
     assert "material deficit" in output

--- a/tests/test_avoid_perpetual.py
+++ b/tests/test_avoid_perpetual.py
@@ -1,7 +1,6 @@
 import chess
 from chess_ai.chess_bot import ChessBot
 from chess_ai.dynamic_bot import DynamicBot
-from core.evaluator import Evaluator
 
 
 def _repetition_board():
@@ -14,17 +13,17 @@ def _repetition_board():
     return board
 
 
-def test_chess_bot_takes_rook_over_check():
+def test_chess_bot_takes_rook_over_check(context, evaluator):
     board = _repetition_board()
+    evaluator.board = board
     bot = ChessBot(chess.WHITE)
-    evaluator = Evaluator(board)
-    move, conf = bot.choose_move(board, evaluator=evaluator)
+    move, conf = bot.choose_move(board, context=context, evaluator=evaluator)
     assert move == chess.Move.from_uci('f7h8')
 
 
-def test_dynamic_bot_takes_rook_over_check():
+def test_dynamic_bot_takes_rook_over_check(context, evaluator):
     board = _repetition_board()
+    evaluator.board = board
     bot = DynamicBot(chess.WHITE)
-    evaluator = Evaluator(board)
-    move, conf = bot.choose_move(board, evaluator=evaluator, debug=False)
+    move, conf = bot.choose_move(board, context=context, evaluator=evaluator, debug=False)
     assert move == chess.Move.from_uci('f7h8')

--- a/tests/test_dynamic_bot.py
+++ b/tests/test_dynamic_bot.py
@@ -4,22 +4,24 @@ import pytest
 from chess_ai.dynamic_bot import DynamicBot
 
 
-def test_meta_agent_combines_weighted_subbots():
+def test_meta_agent_combines_weighted_subbots(context, evaluator):
     board = chess.Board()
+    evaluator.board = board
+
     bot = DynamicBot(chess.WHITE)
     bot.agents = []
 
     class BotA:
-        def choose_move(self, board, context=None, evaluator=None):
+        def choose_move(self, board, context=None, evaluator=None, debug=False):
             return chess.Move.from_uci("e2e4"), 0.6
 
     class BotB:
-        def choose_move(self, board, context=None, evaluator=None):
+        def choose_move(self, board, context=None, evaluator=None, debug=False):
             return chess.Move.from_uci("e2e4"), 0.4
 
     bot.register_agent(BotA(), weight=2.0)
     bot.register_agent(BotB(), weight=0.5)
 
-    move, score = bot.choose_move(board)
+    move, score = bot.choose_move(board, context=context, evaluator=evaluator)
     assert move == chess.Move.from_uci("e2e4")
     assert score == pytest.approx(0.6 * 2.0 + 0.4 * 0.5)

--- a/tests/test_fortify_bot.py
+++ b/tests/test_fortify_bot.py
@@ -4,7 +4,6 @@ import chess
 from chess_ai import fortify_bot
 from chess_ai.fortify_bot import FortifyBot
 from core.constants import KING_SAFETY_THRESHOLD
-from utils import GameContext
 
 
 class DummyEval:
@@ -16,20 +15,21 @@ class DummyEval:
         return 0
 
 
-def test_skips_when_king_safe(capfd):
+def test_skips_when_king_safe(capfd, context, evaluator):
     board = chess.Board()
+    evaluator.board = board
     bot = FortifyBot(chess.WHITE)
-    ctx = GameContext(material_diff=0, mobility=0, king_safety=KING_SAFETY_THRESHOLD)
-    move, score = bot.choose_move(board, context=ctx, debug=True)
+    context.king_safety = KING_SAFETY_THRESHOLD
+    move, score = bot.choose_move(board, context=context, evaluator=evaluator, debug=True)
     assert move is None and score == 0.0
     out = capfd.readouterr().out
     assert "king safety" in out
 
 
-def test_reuses_provided_evaluator(monkeypatch):
+def test_reuses_provided_evaluator(monkeypatch, context):
     board = chess.Board()
     bot = FortifyBot(chess.WHITE)
-    ctx = GameContext(material_diff=0, mobility=0, king_safety=-1)
+    context.king_safety = -1
     dummy = DummyEval()
 
     def boom(*args, **kwargs):
@@ -38,5 +38,5 @@ def test_reuses_provided_evaluator(monkeypatch):
     monkeypatch.setattr(fortify_bot, "Evaluator", boom)
     fortify_bot._SHARED_EVALUATOR = None
 
-    move, score = bot.choose_move(board, context=ctx, evaluator=dummy)
+    move, score = bot.choose_move(board, context=context, evaluator=dummy)
     assert dummy.calls > 0

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -1,9 +1,10 @@
 import chess
 
+import chess
+
 from chess_ai.risk_analyzer import RiskAnalyzer
 from chess_ai.decision_engine import DecisionEngine
 from chess_ai.chess_bot import ChessBot
-from core.evaluator import Evaluator
 
 
 def test_risk_analyzer_detects_hanging_piece():
@@ -62,7 +63,7 @@ def test_decision_engine_avoids_risky_trap(monkeypatch):
     assert best == safe
 
 
-def test_chess_bot_avoids_risky_trap(monkeypatch):
+def test_chess_bot_avoids_risky_trap(monkeypatch, context, evaluator):
     board = chess.Board("r2q2k1/8/8/3B2B1/8/8/8/4K3 w - - 0 1")
     trap = chess.Move.from_uci("g5d8")
     safe = chess.Move.from_uci("d5a8")
@@ -72,7 +73,7 @@ def test_chess_bot_avoids_risky_trap(monkeypatch):
 
     monkeypatch.setattr(RiskAnalyzer, "is_risky", fake_is_risky)
     bot = ChessBot(chess.WHITE)
-    evaluator = Evaluator(board)
-    move, conf = bot.choose_move(board, evaluator=evaluator)
+    evaluator.board = board
+    move, conf = bot.choose_move(board, context=context, evaluator=evaluator)
     assert move == safe
 


### PR DESCRIPTION
## Summary
- add shared Evaluator and GameContext fixtures for tests
- supply context and evaluator to bots in tests
- cover FortifyBot branch when king safety is high

## Testing
- `PYTHONPATH=vendors pytest tests/test_aggressive_bot.py::test_capture_gain_scaled_when_behind tests/test_dynamic_bot.py::test_meta_agent_combines_weighted_subbots tests/test_fortify_bot.py::test_skips_when_king_safe tests/test_fortify_bot.py::test_reuses_provided_evaluator tests/test_avoid_perpetual.py::test_chess_bot_takes_rook_over_check tests/test_avoid_perpetual.py::test_dynamic_bot_takes_rook_over_check tests/test_risk_analyzer.py::test_chess_bot_avoids_risky_trap -q`
- `PYTHONPATH=vendors pytest -q` *(fails: Expected 14, but got 11 ... 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b9e7196c8325997510b1489ebbae