### PR TITLE
Add HybridBot demonstration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ move, score = bot.choose_move(board, debug=True)
 
 The chosen move is the one with the highest total weighted confidence.
 
+## HybridBot demo
+
+A small demonstration script shows the hybrid MCTS/alpha-beta engine in action.
+Run it directly from the repository root:
+
+```bash
+python tests/run_hybrid_demo.py
+```
+
+The script starts from the initial position, lets the hybrid bot play a few
+plies and prints the chosen move, raw MCTS/alpha-beta scores and the time spent
+searching each move.
+

--- a/tests/run_hybrid_demo.py
+++ b/tests/run_hybrid_demo.py
@@ -1,0 +1,54 @@
+"""Demonstration script for :class:`HybridBot`.
+
+Adds vendor paths to ``sys.path`` so that bundled dependencies are used when
+running the script directly.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "vendors"))
+)
+
+import chess
+
+if not hasattr(chess.Board, "transposition_key"):
+    chess.Board.transposition_key = chess.Board._transposition_key  # type: ignore[attr-defined]
+
+from chess_ai.bot_agent import HybridBot
+
+
+def main() -> None:
+    """Run a few plies with ``HybridBot`` from the initial position."""
+    board = chess.Board()
+    bots = {
+        chess.WHITE: HybridBot(chess.WHITE),
+        chess.BLACK: HybridBot(chess.BLACK),
+    }
+
+    for ply in range(4):
+        bot = bots[board.turn]
+        start = time.perf_counter()
+        move, diag = bot.impl.choose_move(board)  # type: ignore[union-attr]
+        elapsed = time.perf_counter() - start
+        board.push(move)
+
+        chosen = diag.get("chosen")
+        cand = next(
+            (c for c in diag.get("candidates", []) if c["move"] == chosen),
+            {},
+        )
+        mcts = cand.get("mcts", 0.0)
+        ab = cand.get("ab", 0.0)
+        print(
+            f"{ply + 1}. {move.uci()} | MCTS={mcts:.3f} AB={ab:.3f} time={elapsed:.2f}s"
+        )
+
+    print(board)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tests/run_hybrid_demo.py` to showcase HybridBot choosing moves and expose diagnostic information
- document the demo in the README with instructions on how to run it

## Testing
- `python tests/run_hybrid_demo.py`
- `PYTHONPATH=vendors pytest -q` *(fails: AssertionError, ValueError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ca1a043c8325b6232a0cae2a7868