### PR TITLE
Bias bots using mobility and material deficit

### DIFF
--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -18,6 +18,10 @@ PIECE_VALUES = {
     chess.KING: 0,
 }
 
+# Additional score applied for each point of material deficit when
+# considering capturing moves.  Encourages material recovery when behind.
+MATERIAL_DEFICIT_BONUS = 10
+
 class ChessBot:
     def __init__(self, color: bool):
         self.color = color
@@ -122,7 +126,7 @@ class ChessBot:
                 gain = PIECE_VALUES[target_piece.piece_type] - PIECE_VALUES[from_piece.piece_type]
                 score += gain
                 if context and context.material_diff < 0:
-                    bonus = abs(context.material_diff) * 10
+                    bonus = abs(context.material_diff) * MATERIAL_DEFICIT_BONUS
                     score += bonus
                     reasons.append(f"material deficit capture bonus (+{bonus})")
                 defenders = board.attackers(not board.turn, move.to_square)

--- a/chess_ai/random_bot.py
+++ b/chess_ai/random_bot.py
@@ -5,6 +5,9 @@ from utils import GameContext
 
 
 _SHARED_EVALUATOR: Evaluator | None = None
+# Small tweak applied when mobility differs between the sides.
+# The bot slightly prefers positions where it has more mobility and
+# de-emphasises ones with less, based only on the sign of the mobility.
 MOBILITY_FACTOR = 0.01
 
 
@@ -45,6 +48,6 @@ class RandomBot:
         tmp = board.copy(stack=False)
         tmp.push(move)
         conf = evaluator.position_score(tmp, self.color)
-        if context is not None:
-            conf += MOBILITY_FACTOR * context.mobility
+        if context is not None and context.mobility != 0:
+            conf += MOBILITY_FACTOR if context.mobility > 0 else -MOBILITY_FACTOR
         return move, float(conf)

--- a/tests/test_chess_bot_material_bonus.py
+++ b/tests/test_chess_bot_material_bonus.py
@@ -1,0 +1,19 @@
+import chess
+
+from chess_ai.chess_bot import ChessBot, MATERIAL_DEFICIT_BONUS
+from utils import GameContext
+
+
+def test_chess_bot_material_deficit_capture_bonus():
+    board = chess.Board("8/8/3p4/8/3P4/8/8/4K3 w - - 0 1")
+    bot = ChessBot(chess.WHITE)
+    move = chess.Move.from_uci("d4d5")
+
+    score_even, _ = bot.evaluate_move(
+        board, move, GameContext(material_diff=0, mobility=0, king_safety=0)
+    )
+    score_behind, _ = bot.evaluate_move(
+        board, move, GameContext(material_diff=-2, mobility=0, king_safety=0)
+    )
+
+    assert score_behind - score_even == 2 * MATERIAL_DEFICIT_BONUS

--- a/tests/test_random_bot.py
+++ b/tests/test_random_bot.py
@@ -1,0 +1,21 @@
+import random
+import chess
+
+from chess_ai.random_bot import RandomBot, MOBILITY_FACTOR
+from utils import GameContext
+
+
+def test_random_bot_mobility_bias():
+    board = chess.Board()
+    bot = RandomBot(chess.WHITE)
+
+    random.seed(0)
+    _, conf_pos = bot.choose_move(
+        board, GameContext(material_diff=0, mobility=5, king_safety=0)
+    )
+    random.seed(0)
+    _, conf_neg = bot.choose_move(
+        board, GameContext(material_diff=0, mobility=-5, king_safety=0)
+    )
+
+    assert conf_pos - conf_neg == 2 * MOBILITY_FACTOR


### PR DESCRIPTION
## Summary
- Nudge RandomBot confidence by the sign of mobility
- Reward ChessBot captures when behind on material
- Cover new behaviours with unit tests

## Testing
- `pytest` *(fails: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc6831c8832596c9576e2eaa1217