### PR TITLE
Refine EndgameBot heuristics using game context

### DIFF
--- a/chess_ai/endgame_bot.py
+++ b/chess_ai/endgame_bot.py
@@ -75,11 +75,11 @@ class EndgameBot:
             defenders = temp.attackers(self.color, from_sq)
             bonus = 100 if defenders else 50
             if context:
-                # Reward checks more when ahead in material and slightly
-                # penalize if our own king is exposed.
-                if context.material_diff > 0:
-                    bonus += context.material_diff * 10
-                bonus += context.king_safety  # negative values lower the bonus
+                # Reward checks more when ahead in material and penalize when
+                # behind.  Also nudge the score based on our own king safety
+                # (negative safety reduces the bonus).
+                bonus += context.material_diff * 10
+                bonus += context.king_safety
             score += bonus
             reason = "check, protected" if defenders else "check"
         piece = board.piece_at(move.from_square)


### PR DESCRIPTION
## Summary
- allow EndgameBot to accept shared `GameContext` and reusable `Evaluator`
- bias check heuristics based on material advantage and king safety

## Testing
- `pytest tests/test_endgame_bot.py::test_check_bonus_scaled_by_material -q` *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68a4d0ed85d48325b704fbb4c84937de