### PR TITLE
Connect usage timeline click handling

### DIFF
--- a/pyside_viewer.py
+++ b/pyside_viewer.py
@@ -153,6 +153,7 @@ class ChessViewer(QWidget):
         # Таймлайн застосованих модулів
         right_col.addWidget(QLabel("Usage timeline:"))
         self.timeline = UsageTimeline()
+        self.timeline.moveClicked.connect(self._on_timeline_click)
         right_col.addWidget(self.timeline)
 
         # Загальна діаграма використання модулів (нижня панель)
@@ -437,6 +438,11 @@ class ChessViewer(QWidget):
     def _update_usage_labels(self):
         self.lbl_usage_w.setText(f"Dynamic usage (W): {self._usage_labels_text(self.usage_w)}")
         self.lbl_usage_b.setText(f"Dynamic usage (B): {self._usage_labels_text(self.usage_b)}")
+
+    def _on_timeline_click(self, index: int, is_white: bool) -> None:
+        """Handle click on the usage timeline by reporting the move index."""
+        side = "W" if is_white else "B"
+        print(f"Timeline click: {side} move {index}")
 
     def _update_status(self, reason: str, feats: dict | None):
         self.lbl_module.setText(f"Модуль: {reason}")

--- a/ui/usage_timeline.py
+++ b/ui/usage_timeline.py
@@ -8,12 +8,13 @@ move index and colour side.
 
 from __future__ import annotations
 
-from PySide6.QtCore import QPoint, Qt, Signal
+from PySide6.QtCore import Qt, Signal, QRect
 from PySide6.QtGui import QPainter, QPen, QFont, QColor, QMouseEvent
 from PySide6.QtWidgets import QWidget
-from PySide6.QtCore import QRect
 
 from utils.module_colors import MODULE_COLORS, REASON_PRIORITY
+
+__all__ = ["UsageTimeline"]
 
 
 class UsageTimeline(QWidget):


### PR DESCRIPTION
## Summary
- expose `UsageTimeline` via module exports and clean imports
- hook `UsageTimeline.moveClicked` in viewer to report clicked moves

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd58248483259848ec762e65ff8b