### PR TITLE
Add MiniBoard widget and scalable cell rendering

### DIFF
--- a/ui/cell.py
+++ b/ui/cell.py
@@ -3,15 +3,18 @@ from PySide6.QtGui import QFont, QColor, QPalette, QPainter
 from PySide6.QtCore import Qt
 from core.constants import SYMBOLS
 
+
 class Cell(QLabel):
-    def __init__(self, row, col, drawer_manager=None):
+    def __init__(self, row, col, drawer_manager=None, scale: float = 1.0):
         super().__init__()
         self.row = row
         self.col = col
         self.drawer_manager = drawer_manager
-        self.setFixedSize(60, 60)
+        self.scale = scale
+        size = int(60 * scale)
+        self.setFixedSize(size, size)
         self.setAlignment(Qt.AlignCenter)
-        self.setFont(QFont("Arial", 28))
+        self.setFont(QFont("Arial", max(1, int(28 * scale))))
         self.base_color = QColor("#eee") if (row + col) % 2 == 0 else QColor("#999")
         self.setAutoFillBackground(True)
         self.set_highlight(False)
@@ -30,55 +33,59 @@ class Cell(QLabel):
     def set_attack_count(self, count):
         self.attack_count = count
         self.update()
-def paintEvent(self, event):
-    super().paintEvent(event)
-    painter = QPainter(self)
-    overlays = []
-    if self.drawer_manager:
-        overlays = self.drawer_manager.get_cell_overlays(self.row, self.col)
-    # Якщо є атака
-    if self.attack_count > 0:
-        if self._piece_symbol:  # є фігура
-            painter.setBrush(QColor("#888"))
-            painter.setPen(Qt.NoPen)
-            painter.drawRect(0, 0, 17, 17)
-            painter.setPen(Qt.white)
-            painter.setFont(QFont("Arial", 8))
-            painter.drawText(0, 0, 17, 17, Qt.AlignCenter, str(self.attack_count))
-        else:  # пуста клітинка
-            x, y, d = 4, 42, 17  # зліва знизу!
-            painter.setBrush(QColor("yellow"))
-            painter.setPen(Qt.NoPen)
-            painter.drawEllipse(x, y, d, d)
-            painter.setPen(Qt.black)
-            painter.setFont(QFont("Arial", 8))
-            painter.drawText(x, y, d, d, Qt.AlignCenter, str(self.attack_count))
-    for overlay_type, color in overlays:
-        if overlay_type == "king_safe":
-            painter.setBrush(QColor("#fff") if color == "white" else QColor("#222"))
-            painter.setPen(Qt.NoPen)
-            painter.drawEllipse(4, 20, 13, 13)
-        elif overlay_type == "king_attacked":
-            painter.setBrush(QColor("red"))
-            painter.setPen(Qt.NoPen)
-            painter.drawEllipse(4, 20, 13, 13)
-        elif overlay_type == "rook_defended":
-            painter.setBrush(QColor("blue"))
-            painter.setPen(Qt.NoPen)
-            painter.drawRect(42, 42, 10, 10)
-        elif overlay_type == "knight_fork":
-            painter.setBrush(QColor("magenta"))
-            painter.setPen(Qt.NoPen)
-            painter.drawEllipse(24, 22, 13, 13)
-        elif overlay_type == "queen_hanging":
-            painter.setBrush(QColor("orange"))
-            painter.setPen(Qt.NoPen)
-            painter.drawRect(4, 42, 10, 10)
-        elif overlay_type == "pin":
-            painter.setBrush(QColor("cyan"))
-            painter.setPen(Qt.NoPen)
-            painter.drawRect(42, 4, 10, 10)
-        elif overlay_type == "check":
-            painter.setBrush(QColor("yellow"))
-            painter.setPen(Qt.NoPen)
-            painter.drawEllipse(42, 4, 10, 10)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        painter = QPainter(self)
+        overlays = []
+        if self.drawer_manager:
+            overlays = self.drawer_manager.get_cell_overlays(self.row, self.col)
+
+        # Якщо є атака
+        if self.attack_count > 0:
+            if self._piece_symbol:  # є фігура
+                d = int(17 * self.scale)
+                painter.setBrush(QColor("#888"))
+                painter.setPen(Qt.NoPen)
+                painter.drawRect(0, 0, d, d)
+                painter.setPen(Qt.white)
+                painter.setFont(QFont("Arial", max(1, int(8 * self.scale))))
+                painter.drawText(0, 0, d, d, Qt.AlignCenter, str(self.attack_count))
+            else:  # пуста клітинка
+                x, y, d = int(4 * self.scale), int(42 * self.scale), int(17 * self.scale)
+                painter.setBrush(QColor("yellow"))
+                painter.setPen(Qt.NoPen)
+                painter.drawEllipse(x, y, d, d)
+                painter.setPen(Qt.black)
+                painter.setFont(QFont("Arial", max(1, int(8 * self.scale))))
+                painter.drawText(x, y, d, d, Qt.AlignCenter, str(self.attack_count))
+
+        for overlay_type, color in overlays:
+            if overlay_type == "king_safe":
+                painter.setBrush(QColor("#fff") if color == "white" else QColor("#222"))
+                painter.setPen(Qt.NoPen)
+                painter.drawEllipse(int(4 * self.scale), int(20 * self.scale), int(13 * self.scale), int(13 * self.scale))
+            elif overlay_type == "king_attacked":
+                painter.setBrush(QColor("red"))
+                painter.setPen(Qt.NoPen)
+                painter.drawEllipse(int(4 * self.scale), int(20 * self.scale), int(13 * self.scale), int(13 * self.scale))
+            elif overlay_type == "rook_defended":
+                painter.setBrush(QColor("blue"))
+                painter.setPen(Qt.NoPen)
+                painter.drawRect(int(42 * self.scale), int(42 * self.scale), int(10 * self.scale), int(10 * self.scale))
+            elif overlay_type == "knight_fork":
+                painter.setBrush(QColor("magenta"))
+                painter.setPen(Qt.NoPen)
+                painter.drawEllipse(int(24 * self.scale), int(22 * self.scale), int(13 * self.scale), int(13 * self.scale))
+            elif overlay_type == "queen_hanging":
+                painter.setBrush(QColor("orange"))
+                painter.setPen(Qt.NoPen)
+                painter.drawRect(int(4 * self.scale), int(42 * self.scale), int(10 * self.scale), int(10 * self.scale))
+            elif overlay_type == "pin":
+                painter.setBrush(QColor("cyan"))
+                painter.setPen(Qt.NoPen)
+                painter.drawRect(int(42 * self.scale), int(4 * self.scale), int(10 * self.scale), int(10 * self.scale))
+            elif overlay_type == "check":
+                painter.setBrush(QColor("yellow"))
+                painter.setPen(Qt.NoPen)
+                painter.drawEllipse(int(42 * self.scale), int(4 * self.scale), int(10 * self.scale), int(10 * self.scale))

--- a/ui/mini_board.py
+++ b/ui/mini_board.py
@@ -1,0 +1,76 @@
+"""Miniature chess board widget.
+
+This widget displays a scaled-down chess board.  It is intended for
+showing positions without interaction – for example, as a preview or in
+dashboards.  The implementation reuses :class:`Cell` so it honours the
+same overlay logic provided by :class:`DrawerManager` while rendering at a
+fraction of the normal size.
+"""
+
+from __future__ import annotations
+
+import chess
+from PySide6.QtWidgets import QWidget, QFrame, QGridLayout
+
+from ui.cell import Cell
+from ui.drawer_manager import DrawerManager
+from core.piece import piece_class_factory
+
+
+class MiniBoard(QWidget):
+    """A non-interactive, scaled board for displaying FEN positions."""
+
+    def __init__(self, parent=None, scale: float = 0.25):
+        super().__init__(parent)
+        self.scale = scale
+        self.board = chess.Board()
+        self.drawer_manager = DrawerManager()
+
+        board_size = int(60 * 8 * scale)
+        self.board_frame = QFrame(self)
+        self.board_frame.setFixedSize(board_size, board_size)
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.board_frame, 0, 0)
+
+        self.grid = QGridLayout(self.board_frame)
+        self.grid.setContentsMargins(0, 0, 0, 0)
+        self.grid.setSpacing(0)
+
+        self.cell_grid = [[None for _ in range(8)] for _ in range(8)]
+        for row in range(8):
+            for col in range(8):
+                cell = Cell(row, col, self.drawer_manager, scale=scale)
+                self.grid.addWidget(cell, row, col)
+                self.cell_grid[row][col] = cell
+
+    # ------------------------------------------------------------------
+    def set_fen(self, fen: str) -> None:
+        """Load a position from ``fen`` and redraw the board."""
+
+        self.board.set_fen(fen)
+        self._refresh_board()
+
+    # ------------------------------------------------------------------
+    def _refresh_board(self) -> None:
+        piece_objects = {}
+        for square in chess.SQUARES:
+            piece = self.board.piece_at(square)
+            if piece:
+                pos = (chess.square_rank(square), chess.square_file(square))
+                piece_objects[square] = piece_class_factory(piece, pos)
+
+        self.drawer_manager.collect_overlays(piece_objects, self.board)
+
+        for row in range(8):
+            for col in range(8):
+                square = chess.square(col, 7 - row)
+                piece = self.board.piece_at(square)
+                cell = self.cell_grid[row][col]
+                cell.set_piece(piece.symbol() if piece else None)
+                attackers = self.board.attackers(not self.board.turn, square)
+                cell.set_attack_count(len(attackers))
+                cell.set_highlight(False)
+                cell.update()
+


### PR DESCRIPTION
## Summary
- extend `Cell` with a scale factor so cell size, fonts and overlays can be scaled for miniature boards
- add `MiniBoard` widget that reuses existing `Cell` and `DrawerManager` to show a FEN position at 1/4 size

## Testing
- `PYTHONPATH=vendors pytest` *(fails: 8 failed, 34 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d6e3153c832586e0d3e251bbaad7