### PR TITLE
Add run selector GUI entry point

### DIFF
--- a/run_selector.py
+++ b/run_selector.py
@@ -1,0 +1,32 @@
+"""Entry point for selecting recorded runs.
+
+Usage:
+    python run_selector.py --runs path/to/dir
+"""
+
+import argparse
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from utils.load_runs import load_runs
+from ui.run_selector_window import RunSelectorWindow
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run selector GUI")
+    parser.add_argument(
+        "--runs", default="runs/", help="Directory containing run JSON files"
+    )
+    args = parser.parse_args(argv)
+
+    runs = load_runs(args.runs)
+
+    app = QApplication(sys.argv)
+    window = RunSelectorWindow(runs)
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    sys.exit(main())

--- a/ui/run_selector_window.py
+++ b/ui/run_selector_window.py
@@ -1,0 +1,19 @@
+from PySide6.QtWidgets import QWidget, QListWidget, QVBoxLayout, QLabel
+
+
+class RunSelectorWindow(QWidget):
+    """Window that displays available recorded runs."""
+
+    def __init__(self, runs):
+        super().__init__()
+        self.setWindowTitle("Run Selector")
+        self.runs = list(runs)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Available runs"))
+
+        self.list_widget = QListWidget()
+        for run in self.runs:
+            game_id = run.get("game_id", "<unknown>")
+            self.list_widget.addItem(game_id)
+        layout.addWidget(self.list_widget)


### PR DESCRIPTION
## Summary
- Add `RunSelectorWindow` widget for displaying available runs
- Create `run_selector.py` CLI to load run JSON files and launch the selector

## Testing
- `pytest` *(fails: Expected 14, but got 11. And other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e62f8f9c83258ff61e6e3d822b75