### PR TITLE
Refactor attacked square metric to accept square

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -1,15 +1,21 @@
 import chess
+from typing import Union
 
-def calculate_attacked_squares(piece: chess.Piece, board: chess.Board):
+
+def calculate_attacked_squares(square: Union[int, chess.Square], board: chess.Board) -> list[int]:
+    """Calculate squares attacked from ``square`` on ``board``.
+
+    Parameters
+    ----------
+    square:
+        Index or :class:`chess.Square` where the piece resides.
+    board:
+        The current :class:`chess.Board` instance.
+
+    Returns
+    -------
+    list[int]
+        Squares (as integers) that the piece attacks.
     """
-    Calculate all squares attacked by a given piece on the board.
-    :param piece: A chess.Piece instance
-    :param board: A chess.Board instance
-    :return: A list of squares (as integers) that the piece attacks
-    """
-    piece_square = next(
-        square for square in chess.SQUARES
-        if board.piece_at(square) == piece
-    )
-    attacked_squares = board.attacks(piece_square)
+    attacked_squares = board.attacks(square)
     return list(attacked_squares)

--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -1,15 +1,14 @@
 import chess
 from attacked_squares import calculate_attacked_squares
 
+
 def test_attacked_squares():
     # Set up a simple position
     board = chess.Board()
     board.set_fen("8/8/8/8/8/8/8/R7 w - - 0 1")
     board.set_piece_at(chess.E1, chess.Piece(chess.ROOK, chess.WHITE))
 
-    # Get the rook piece from the board
-    rook = board.piece_at(chess.E1)
-    result = calculate_attacked_squares(rook, board)
+    result = calculate_attacked_squares(chess.E1, board)
 
     # Check the number of attacked squares
     expected_number_of_squares = 14  # Rook on e1 with another rook on a1
@@ -17,6 +16,7 @@ def test_attacked_squares():
         f"Expected {expected_number_of_squares}, but got {len(result)}."
 
     print("test_attacked_squares passed!")
+
 
 if __name__ == "__main__":
     test_attacked_squares()


### PR DESCRIPTION
## Summary
- refactor calculate_attacked_squares to take a square instead of a piece
- simplify attacked square lookup and update corresponding test

## Testing
- `pytest` *(fails: test suite has 7 failing tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6891b5c8325be059a115f11d3a1