### PR TITLE
Refactor attacked square calculation to accept square index

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -17,5 +17,5 @@ def calculate_attacked_squares(square: Union[int, chess.Square], board: chess.Bo
     list[int]
         Squares (as integers) that the piece attacks.
     """
-    attacked_squares = board.attacks(square)
-    return list(attacked_squares)
+    square_index = int(square)
+    return list(board.attacks(square_index))

--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -8,7 +8,7 @@ def test_attacked_squares():
     board.set_fen("8/8/8/8/8/8/8/R7 w - - 0 1")
     board.set_piece_at(chess.E1, chess.Piece(chess.ROOK, chess.WHITE))
 
-    result = calculate_attacked_squares(chess.E1, board)
+    result = calculate_attacked_squares(int(chess.E1), board)
 
     # Check the number of attacked squares
     expected_number_of_squares = 14  # Rook on e1 with another rook on a1


### PR DESCRIPTION
## Summary
- Handle attacked-square calculation directly from a board square index
- Adjust attacked squares tests to pass square index explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f37a6e28832584c5cc4d6163acc6