### PR TITLE
Use python-chess helpers for piece attack squares

### DIFF
--- a/core/piece.py
+++ b/core/piece.py
@@ -27,9 +27,11 @@ class Piece:
     def get_attacked_squares(self, board):
         """Return squares this piece attacks using python-chess helpers."""
 
-        if chess is None:
+        if chess is None:  # pragma: no cover - defensive fallback
             return set()
-        square = chess.square(self.position[1], self.position[0])
+
+        rank, file = self.position
+        square = chess.square(file, rank)
         return set(board.attacks(square))
 
 class Pawn(Piece):
@@ -42,6 +44,7 @@ class Rook(Piece):
     def update_defended(self, board):
         self.defended_moves.clear()
         self.attacked_moves.clear()
+
         for sq in self.get_attacked_squares(board):
             piece = board.piece_at(sq)
             if piece and piece.color == self.color:

--- a/tests/test_piece_attacks.py
+++ b/tests/test_piece_attacks.py
@@ -1,4 +1,5 @@
 import chess
+import pytest
 
 from core.piece import piece_class_factory
 
@@ -33,3 +34,24 @@ def test_knight_attacks():
 
     expected_attacks = set(board.attacks(knight_sq))
     assert knight.get_attacked_squares(board) == expected_attacks
+
+
+@pytest.mark.parametrize(
+    "piece_type, square",
+    [
+        (chess.BISHOP, chess.square(2, 2)),  # c3
+        (chess.QUEEN, chess.square(4, 4)),  # e5
+        (chess.KING, chess.square(4, 4)),  # e5
+        (chess.PAWN, chess.square(3, 3)),  # d4
+    ],
+)
+def test_other_pieces_attacks(piece_type, square):
+    board = chess.Board()
+    board.clear()
+    board.set_piece_at(square, chess.Piece(piece_type, chess.WHITE))
+
+    pos = (chess.square_rank(square), chess.square_file(square))
+    piece = piece_class_factory(board.piece_at(square), pos)
+
+    expected_attacks = set(board.attacks(square))
+    assert piece.get_attacked_squares(board) == expected_attacks


### PR DESCRIPTION
## Summary
- compute attacked squares with python-chess using board.attacks
- leverage helpers to classify rook defended vs attacked squares
- expand tests to verify attack squares for multiple piece types

## Testing
- `pytest tests/test_piece_attacks.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a588bf0d28832591134404ccda1d39