### PR TITLE
Centralize vendor path setup in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "vendors"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "vendors"))
 
 import chess
 import pytest


### PR DESCRIPTION
## Summary
- Use `tests/conftest.py` to add the `vendors` directory to `sys.path`
- Remove per-file `sys.path` adjustments from individual tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a588d711d08325b6db753d36d6927a