### PR TITLE
Implement python-chess attack/defense helpers and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Vendored dependencies
+- Use libraries in `vendors/` before installing external packages.
+- To import the vendored chess library, ensure `vendors` is added to `sys.path` (see `tests/conftest.py`).
+
+## Testing
+- Run `pytest` after code changes. For quick checks you can run a subset, e.g. `pytest tests/test_random_bot.py -q`.
+
+## GameContext
+- `GameContext` metrics default to zero; tests only specify non-zero fields.

--- a/core/board_analyzer.py
+++ b/core/board_analyzer.py
@@ -4,9 +4,9 @@ class BoardAnalyzer:
 
     def get_all_attacks(self, color):
         attacks = set()
-        for piece in self.board.get_pieces(color):
-            squares = piece.get_attacked_squares(self.board)
-            attacks.update(squares)
+        color_flag = color if isinstance(color, bool) else (color == 'white')
+        for piece in self.board.get_pieces(color_flag):
+            attacks.update(piece.get_attacked_squares(self.board))
         return attacks
 
     def get_threat_map(self):
@@ -17,7 +17,7 @@ class BoardAnalyzer:
 
     def get_defense_map(self, color):
         defenses = set()
-        for piece in self.board.get_pieces(color):
-            if hasattr(piece, 'get_defended_squares'):
-                defenses.update(piece.get_defended_squares(self.board))
+        color_flag = color if isinstance(color, bool) else (color == 'white')
+        for piece in self.board.get_pieces(color_flag):
+            defenses.update(piece.get_defended_squares(self.board))
         return defenses

--- a/core/utils.py
+++ b/core/utils.py
@@ -9,9 +9,9 @@ from core.piece import Piece, Pawn, Rook, Knight, Bishop, Queen, King
 class GameContext:
     """Shared positional metrics available to all agents."""
 
-    material_diff: int
-    mobility: int
-    king_safety: int
+    material_diff: int = 0
+    mobility: int = 0
+    king_safety: int = 0
 
 def piece_class_factory(piece, pos):
     t = piece.symbol().lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "vendors"))
+
 import chess
 import pytest
 
@@ -14,4 +19,4 @@ def evaluator():
 @pytest.fixture
 def context():
     """Minimal game context with neutral metrics."""
-    return GameContext(material_diff=0, mobility=0, king_safety=0)
+    return GameContext()

--- a/tests/test_aggressive_bot.py
+++ b/tests/test_aggressive_bot.py
@@ -6,7 +6,7 @@ from utils import GameContext
 def test_capture_gain_scaled_when_behind(capfd, evaluator):
     board = chess.Board("8/8/8/3r4/2P5/8/8/8 w - - 0 1")
     evaluator.board = board
-    ctx = GameContext(material_diff=-1, mobility=0, king_safety=0)
+    ctx = GameContext(material_diff=-1)
     bot = AggressiveBot(chess.WHITE, capture_gain_factor=1.5)
     move, score = bot.choose_move(board, context=ctx, evaluator=evaluator, debug=True)
     assert move == chess.Move.from_uci("c4d5")

--- a/tests/test_board_analyzer_defense.py
+++ b/tests/test_board_analyzer_defense.py
@@ -1,0 +1,23 @@
+import chess
+
+from core.board_analyzer import BoardAnalyzer
+from core.piece import piece_class_factory
+
+
+class AnalysisBoard(chess.Board):
+    def get_pieces(self, color=None):
+        pieces = []
+        for sq, piece in self.piece_map().items():
+            pos = (chess.square_rank(sq), chess.square_file(sq))
+            pieces.append(piece_class_factory(piece, pos))
+        if color is None:
+            return pieces
+        color_flag = color if isinstance(color, bool) else (color == 'white')
+        return [p for p in pieces if p.color == color_flag]
+
+
+def test_rook_defends_pawn():
+    board = AnalysisBoard("8/8/8/8/8/8/P7/R7 w - - 0 1")
+    analyzer = BoardAnalyzer(board)
+    defenses = analyzer.get_defense_map('white')
+    assert chess.A2 in defenses

--- a/tests/test_chess_bot_material_bonus.py
+++ b/tests/test_chess_bot_material_bonus.py
@@ -10,10 +10,10 @@ def test_chess_bot_material_deficit_capture_bonus():
     move = chess.Move.from_uci("d4d5")
 
     score_even, _ = bot.evaluate_move(
-        board, move, GameContext(material_diff=0, mobility=0, king_safety=0)
+        board, move, GameContext()
     )
     score_behind, _ = bot.evaluate_move(
-        board, move, GameContext(material_diff=-2, mobility=0, king_safety=0)
+        board, move, GameContext(material_diff=-2)
     )
 
     assert score_behind - score_even == 2 * MATERIAL_DEFICIT_BONUS

--- a/tests/test_endgame_bot.py
+++ b/tests/test_endgame_bot.py
@@ -16,14 +16,14 @@ def test_check_bonus_scaled_by_material():
         board,
         move,
         enemy_king,
-        GameContext(material_diff=0, mobility=0, king_safety=0),
+        GameContext(),
     )
     random.seed(0)
     ahead_score, _ = bot.evaluate_move(
         board,
         move,
         enemy_king,
-        GameContext(material_diff=2, mobility=0, king_safety=0),
+        GameContext(material_diff=2),
     )
 
     assert ahead_score > base_score

--- a/tests/test_piece_attacks.py
+++ b/tests/test_piece_attacks.py
@@ -1,0 +1,22 @@
+import chess
+
+from core.piece import piece_class_factory
+
+
+def _piece_from_square(board: chess.Board, square: int):
+    piece = board.piece_at(square)
+    assert piece is not None
+    pos = (chess.square_rank(square), chess.square_file(square))
+    return piece_class_factory(piece, pos)
+
+
+def test_rook_attacks_match_python_chess():
+    board = chess.Board("8/8/8/3R4/8/8/8/8 w - - 0 1")
+    rook = _piece_from_square(board, chess.D5)
+    assert rook.get_attacked_squares(board) == board.attacks(chess.D5)
+
+
+def test_knight_attacks_match_python_chess():
+    board = chess.Board("8/8/8/3N4/8/8/8/8 w - - 0 1")
+    knight = _piece_from_square(board, chess.D5)
+    assert knight.get_attacked_squares(board) == board.attacks(chess.D5)

--- a/tests/test_random_bot.py
+++ b/tests/test_random_bot.py
@@ -11,11 +11,11 @@ def test_random_bot_mobility_bias():
 
     random.seed(0)
     _, conf_pos = bot.choose_move(
-        board, GameContext(material_diff=0, mobility=5, king_safety=0)
+        board, GameContext(mobility=5)
     )
     random.seed(0)
     _, conf_neg = bot.choose_move(
-        board, GameContext(material_diff=0, mobility=-5, king_safety=0)
+        board, GameContext(mobility=-5)
     )
 
     assert conf_pos - conf_neg == 2 * MOBILITY_FACTOR


### PR DESCRIPTION
## Summary
- compute attacked and defended squares for each piece using python-chess
- aggregate defended squares in BoardAnalyzer
- add regression tests for piece attacks and defense mapping

## Testing
- `pytest tests/test_piece_attacks.py tests/test_board_analyzer_defense.py -q`
- `pytest -q` *(fails: test_attacked_squares, test_search_batch_calls_net_and_returns_move, test_chess_bot_material_bonus, test_capture_beats_perpetual_check, test_check_bonus_scaled_by_material, test_pawn_structure_score_doubled_black, test_alpha_beta_prunes, test_decision_engine_avoids_risky_trap)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e46e3860832583182eb384d9544b