### PR TITLE
docs: add vendored dependency guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Vendored dependencies
 - `tests/conftest.py` automatically appends `vendors/` to `sys.path`. When running scripts outside the test suite, manually add `vendors/` to `sys.path`.
+- If a required third-party library is missing, copy it into `vendors/` instead of installing it globally; adjust the `sys.path` update if necessary to import it correctly.
 
 ## Testing
 - Run `pytest` after code changes. For quick checks you can run a subset, e.g. `pytest tests/test_random_bot.py -q`.


### PR DESCRIPTION
## Summary
- clarify vendored dependency guidance in `AGENTS.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a591af8d408325988eab37edcb16ca