### PR TITLE
test: assert custom evaluator usage

### DIFF
--- a/tests/test_fortify_bot.py
+++ b/tests/test_fortify_bot.py
@@ -40,3 +40,6 @@ def test_reuses_provided_evaluator(monkeypatch, context):
 
     move, score = bot.choose_move(board, context=context, evaluator=dummy)
     assert dummy.calls > 0
+    assert move is not None
+    # ensure that providing an evaluator doesn't populate the shared instance
+    assert fortify_bot._SHARED_EVALUATOR is None


### PR DESCRIPTION
## Summary
- extend FortifyBot tests to ensure custom evaluator produces a move and does not set shared evaluator

## Testing
- `pytest tests/test_fortify_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5918b1a0c83259912b64e720aca66