### PR TITLE
Add module usage pie chart to run selector

### DIFF
--- a/tests/test_run_selector_window.py
+++ b/tests/test_run_selector_window.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication
+
+from ui.run_selector_window import RunSelectorWindow
+
+
+def test_run_selector_aggregates_module_usage():
+    app = QApplication.instance() or QApplication([])
+    runs = [
+        {"game_id": "g1", "moves": [], "fens": [], "modules_w": ["A"], "modules_b": ["B"]},
+        {"game_id": "g2", "moves": [], "fens": [], "modules_w": ["A"], "modules_b": ["A", "B"]},
+    ]
+    window = RunSelectorWindow(runs)
+    expected = {"A": 3, "B": 2}
+    assert window.usage_counts == expected
+    assert window.usage_pie.counts == expected
+    window.close()
+
+
+if __name__ == "__main__":
+    test_run_selector_aggregates_module_usage()
+

--- a/ui/run_selector_window.py
+++ b/ui/run_selector_window.py
@@ -11,6 +11,8 @@ from PySide6.QtWidgets import (
 
 from ui.mini_board import MiniBoard
 from ui.usage_timeline import UsageTimeline
+from ui.usage_pie import UsagePie
+from utils.module_usage import aggregate_module_usage
 
 
 class RunSelectorWindow(QWidget):
@@ -44,11 +46,22 @@ class RunSelectorWindow(QWidget):
         right.addWidget(QLabel("Moves"))
         right.addWidget(self.moves)
 
+        # --- Overall module usage pie --------------------------------------------
+        self.usage_pie = UsagePie()
+        self.usage_counts = aggregate_module_usage(self.runs)
+        self.usage_pie.set_counts(self.usage_counts)
+
         # --- Assemble layout ------------------------------------------------------
-        layout = QHBoxLayout(self)
-        layout.addWidget(self.list_widget)
-        layout.addLayout(centre)
-        layout.addLayout(right)
+        layout_main = QVBoxLayout(self)
+        top = QHBoxLayout()
+        top.addWidget(self.list_widget)
+        top.addLayout(centre)
+        top.addLayout(right)
+        layout_main.addLayout(top)
+        pie_box = QVBoxLayout()
+        pie_box.addWidget(QLabel("Overall module usage"))
+        pie_box.addWidget(self.usage_pie)
+        layout_main.addLayout(pie_box)
 
         if self.runs:
             self.list_widget.setCurrentRow(0)

--- a/ui/usage_pie.py
+++ b/ui/usage_pie.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple pie chart visualising aggregated module usage."""
+
+from typing import Mapping, Dict
+
+from PySide6.QtCore import Qt, QRect
+from PySide6.QtGui import QPainter, QColor
+from PySide6.QtWidgets import QWidget
+
+from utils.module_colors import MODULE_COLORS
+
+
+class UsagePie(QWidget):
+    """Draw a pie chart representing module usage share."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.counts: Dict[str, int] = {}
+        self.setMinimumHeight(100)
+
+    def set_counts(self, counts: Mapping[str, int]) -> None:
+        """Set *counts* mapping module name to occurrence count."""
+
+        self.counts = {k: int(v) for k, v in counts.items() if v}
+        self.update()
+
+    # ------------------------------------------------------------------
+    def paintEvent(self, ev) -> None:  # pragma: no cover - GUI drawing
+        painter = QPainter(self)
+        painter.fillRect(self.rect(), QColor(250, 250, 250))
+
+        total = sum(self.counts.values())
+        if total <= 0:
+            return
+
+        size = min(self.width(), self.height()) - 20
+        rect = QRect((self.width() - size) // 2, (self.height() - size) // 2, size, size)
+
+        start = 0.0
+        for key in sorted(self.counts, key=self.counts.get, reverse=True):
+            span = self.counts[key] / total * 360
+            color = MODULE_COLORS.get(key, MODULE_COLORS["OTHER"])
+            painter.setBrush(color)
+            painter.setPen(Qt.NoPen)
+            painter.drawPie(rect, int(start * 16), int(span * 16))
+            start += span
+


### PR DESCRIPTION
## Summary
- aggregate module usage across loaded runs
- display an overall usage pie chart below the Run Selector
- add tests ensuring stats aggregation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a59251e0bc8325b14a955d819435de