### PR TITLE
Update test fixtures for vendor path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "vendors"))
+# Ensure vendored dependencies are importable by adding the ``vendor``
+# directory to ``sys.path`` before any other imports occur.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "vendor"))
 
 import chess
 import pytest


### PR DESCRIPTION
## Summary
- ensure tests import vendored dependencies by adding the `vendor` directory to `sys.path` in `tests/conftest.py`

## Testing
- `pytest tests/test_new_metrics.py -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a3d6d644832589e4be158f335804