### PR TITLE
Refactor piece attack/defense logic

### DIFF
--- a/core/board_analyzer.py
+++ b/core/board_analyzer.py
@@ -14,17 +14,11 @@ class BoardAnalyzer:
             'white': self.get_all_attacks('white'),
             'black': self.get_all_attacks('black')
         }
-
-    def _collect_defenses(self, color):
-        """Gather defended squares for ``color`` pieces."""
-        defenses = set()
-        for piece in self.board.get_pieces(color):
-            defenses.update(piece.get_defended_squares(self.board))
-        return defenses
-
+    
     def get_defense_map(self):
         """Return mapping of color to defended squares on the board."""
-        return {
-            'white': self._collect_defenses('white'),
-            'black': self._collect_defenses('black')
-        }
+        defense_map = {'white': set(), 'black': set()}
+        for color in ('white', 'black'):
+            for piece in self.board.get_pieces(color):
+                defense_map[color].update(piece.get_defended_squares(self.board))
+        return defense_map

--- a/core/piece.py
+++ b/core/piece.py
@@ -88,10 +88,14 @@ class Rook(Piece):
         self.defended_moves.clear()
         self.attacked_moves.clear()
 
-        attacked = self.get_attacked_squares(board)
-        defended = self.get_defended_squares(board)
-        self.defended_moves.update(defended)
-        self.attacked_moves.update(attacked - defended)
+        for sq in self.get_attacked_squares(board):
+            piece = board.piece_at(sq)
+            if piece is None:
+                continue
+            if piece.color == self.color:
+                self.defended_moves.add(sq)
+            else:
+                self.attacked_moves.add(sq)
 
 class Knight(Piece):
     def __init__(self, color, position):

--- a/tests/test_piece_attacks.py
+++ b/tests/test_piece_attacks.py
@@ -21,7 +21,8 @@ def test_rook_attacks_and_defense():
 
     rook.update_defended(board)
     assert rook.defended_moves == {chess.square(3, 5)}
-    assert rook.attacked_moves == expected_attacks - {chess.square(3, 5)}
+    # ``attacked_moves`` now only tracks enemy targets
+    assert rook.attacked_moves == {chess.square(6, 3)}
 
 
 def test_knight_attacks():


### PR DESCRIPTION
## Summary
- Use python-chess square conversion and attack helpers in core pieces
- Distinguish enemy vs friendly targets in rook overlays
- Aggregate defended squares per color in BoardAnalyzer
- Update tests for new rook classification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a8dc7bd08325a94a066dd686acfa