### PR TITLE
Use iterator-safe mobility counting

### DIFF
--- a/chess_ai/evaluator.py
+++ b/chess_ai/evaluator.py
@@ -36,7 +36,7 @@ class Evaluator:
 
         # Кількість можливих ходів (ігноруємо клітини з власними фігурами)
         attacks = self.board.attacks(piece_sq)
-        mobility = len([sq for sq in attacks if self.board.color_at(sq) != piece_color])
+        mobility = sum(1 for sq in attacks if self.board.color_at(sq) != piece_color)
         features["active_piece"] = mobility
 
         # Перевіряємо, чи вийшла фігура на повністю відкриту вертикаль

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -43,20 +43,18 @@ class Evaluator:
         """
         board = board or self.board
         orig_turn = board.turn
-        # Use ``count()`` instead of ``len()`` because ``legal_moves`` is a
-        # generator.  If ``count()`` is unavailable or requires an argument
-        # (like on plain lists), fall back to summing over the iterator.
-        moves = board.legal_moves
-        try:
-            white_moves = moves.count()
-        except (AttributeError, TypeError):
-            white_moves = sum(1 for _ in moves)
+
+        def _move_count(moves):
+            """Count moves without materializing the generator."""
+            try:
+                return moves.count()
+            except (AttributeError, TypeError):
+                return sum(1 for _ in moves)
+
+        # Count white's moves, then temporarily flip the turn to count black's.
+        white_moves = _move_count(board.legal_moves)
         board.turn = not board.turn
-        moves = board.legal_moves
-        try:
-            black_moves = moves.count()
-        except (AttributeError, TypeError):
-            black_moves = sum(1 for _ in moves)
+        black_moves = _move_count(board.legal_moves)
         board.turn = orig_turn
         score = white_moves - black_moves
         self.mobility_stats = {"white": white_moves, "black": black_moves, "score": score}


### PR DESCRIPTION
## Summary
- Avoid len() on `board.legal_moves` by introducing `_move_count` helper
- Calculate piece activity without materializing lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5aa5ab7c88325b93109460de33a5d