### PR TITLE
Simplify attacked squares metric using python-chess

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -4,6 +4,11 @@ import chess
 def calculate_attacked_squares(square: int, board: chess.Board) -> list[int]:
     """Calculate squares attacked from ``square`` on ``board``.
 
+    The function is a light wrapper around :meth:`chess.Board.attacks`.
+    ``Board.attacks`` returns a :class:`chess.SquareSet`, which is converted
+    into a regular ``list`` of integers to keep downstream assertions and
+    metrics straightforward.
+
     Parameters
     ----------
     square:
@@ -16,4 +21,5 @@ def calculate_attacked_squares(square: int, board: chess.Board) -> list[int]:
     list[int]
         Squares (as integers) that the piece attacks.
     """
+
     return list(board.attacks(square))

--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -1,23 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "vendors"))
+)
+
 import chess
 from attacked_squares import calculate_attacked_squares
 
 
-def test_attacked_squares():
-    # Set up a simple position
+def test_attacked_squares() -> None:
+    """Verify the number of squares a rook attacks."""
     board = chess.Board()
     board.set_fen("8/8/8/8/8/8/8/R7 w - - 0 1")
     square = chess.E1
     board.set_piece_at(square, chess.Piece(chess.ROOK, chess.WHITE))
 
     result = calculate_attacked_squares(square, board)
+    expected = list(board.attacks(square))
 
-    # Check the number of attacked squares
-    expected_number_of_squares = 14  # Rook on e1 with another rook on a1
-    assert len(result) == expected_number_of_squares, \
-        f"Expected {expected_number_of_squares}, but got {len(result)}."
-
-    print("test_attacked_squares passed!")
-
-
-if __name__ == "__main__":
-    test_attacked_squares()
+    assert result == expected
+    assert len(result) == 14  # Rook on e1 with another rook on a1


### PR DESCRIPTION
## Summary
- Wrap `chess.Board.attacks` to compute attacked squares and return a plain list
- Load vendored `chess` library in tests and verify the metric against `Board.attacks`

## Testing
- `pytest metrics/test_attacked_squares.py -q`
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5af04171c8325b7d09f13e9c2f34a