### PR TITLE
test: ensure calculate_attacked_squares raises on missing piece

### DIFF
--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -26,11 +26,12 @@ def test_attacked_squares() -> None:
     assert len(result) == 14  # Rook on e1 on an otherwise empty board
 
 
-def test_missing_piece() -> None:
-    """Ensure a ``ValueError`` is raised when the piece is absent."""
+def test_calculate_attacked_squares_without_piece() -> None:
+    """``calculate_attacked_squares`` requires the piece to be on the board."""
     board = chess.Board()
-    board.clear()
-    piece = chess.Piece(chess.BISHOP, chess.WHITE)
+    board.clear()  # Ensure the board has no pieces
+    missing_piece = chess.Piece(chess.BISHOP, chess.WHITE)
 
     with pytest.raises(ValueError):
-        calculate_attacked_squares(piece, board)
+        calculate_attacked_squares(missing_piece, board)
+


### PR DESCRIPTION
## Summary
- verify calculate_attacked_squares raises ValueError when the piece isn't on the board

## Testing
- `pytest metrics/test_attacked_squares.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b62416a88325ba28b8ef8aaf192e