### PR TITLE
Emphasize material in search and test base depth

### DIFF
--- a/chess_ai/decision_engine.py
+++ b/chess_ai/decision_engine.py
@@ -52,7 +52,11 @@ class DecisionEngine:
         horizon effect.
         """
         if depth == 0 or board.is_game_over() or board.is_repetition(3):
-            return quiescence(board, alpha, beta)
+            # Scale the quiescence search to emphasise material balance
+            # without distorting the alpha--beta window.
+            scaled_alpha = alpha / self.material_weight
+            scaled_beta = beta / self.material_weight
+            return quiescence(board, scaled_alpha, scaled_beta) * self.material_weight
 
         best = float("-inf")
         for move in board.legal_moves:

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -1,6 +1,7 @@
 import chess
 
 from chess_ai.decision_engine import DecisionEngine
+from chess_ai.risk_analyzer import RiskAnalyzer
 
 
 def test_capture_beats_perpetual_check():
@@ -17,4 +18,22 @@ def test_quiescence_avoids_hanging_capture():
     engine = DecisionEngine()
     best = engine.choose_best_move(board)
     assert best != chess.Move.from_uci("a4a5"), "Engine should avoid losing the queen"
+
+
+def test_base_depth_passed_to_search(monkeypatch):
+    """Engine should honour the configured ``base_depth`` when searching."""
+    board = chess.Board()
+    engine = DecisionEngine(base_depth=3)
+
+    depths = []
+
+    def fake_search(self, b, depth, alpha=-float("inf"), beta=float("inf")):
+        depths.append(depth)
+        return 0
+
+    monkeypatch.setattr(DecisionEngine, "search", fake_search)
+    monkeypatch.setattr(RiskAnalyzer, "is_risky", lambda self, b, m: False)
+
+    engine.choose_best_move(board)
+    assert depths and all(d == 3 for d in depths)
 

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -74,3 +74,12 @@ def test_chess_bot_avoids_risky_trap(monkeypatch, context, evaluator):
     move, conf = bot.choose_move(board, context=context, evaluator=evaluator)
     assert move == safe
 
+
+def test_engine_prefers_safe_valuable_capture(monkeypatch):
+    """When no moves are risky, the engine should capture valuable pieces."""
+    board = chess.Board("r3n1k1/8/8/3Q4/8/8/8/5K2 w - - 0 1")
+    monkeypatch.setattr(RiskAnalyzer, "is_risky", lambda self, b, m: False)
+    engine = DecisionEngine()
+    best = engine.choose_best_move(board)
+    assert best == chess.Move.from_uci("d5a8")
+


### PR DESCRIPTION
## Summary
- Weight quiescence evaluation in `DecisionEngine.search` by `material_weight`, keeping alpha–beta window consistent.
- Add tests ensuring the engine uses the configured base depth and prefers safe high-value captures.

## Testing
- `pytest tests/test_decision_engine.py tests/test_risk_analyzer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b96f92848325afc3fb4bcddc0313