### PR TITLE
Improve alpha-beta pruning test

### DIFF
--- a/chess_ai/risk_analyzer.py
+++ b/chess_ai/risk_analyzer.py
@@ -65,11 +65,14 @@ class RiskAnalyzer:
         if depth == 0 or board.is_game_over():
             stand_pat = self._material(board, color)
             # Quiescence: search further only through captures
-            for mv in board.legal_moves:
+            legal = board.generate_legal_moves()
+            while beta > alpha:
+                try:
+                    mv = next(legal)
+                except StopIteration:
+                    break
                 if not board.is_capture(mv):
                     continue
-                if beta <= alpha:
-                    break
                 board.push(mv)
                 score = self._search(board, 0, not maximizing, color, alpha, beta)
                 board.pop()
@@ -87,8 +90,11 @@ class RiskAnalyzer:
 
         if maximizing:
             best = -float("inf")
-            for mv in board.legal_moves:
-                if beta <= alpha:
+            legal = board.generate_legal_moves()
+            while beta > alpha:
+                try:
+                    mv = next(legal)
+                except StopIteration:
                     break
                 board.push(mv)
                 to_sq = mv.to_square
@@ -108,8 +114,11 @@ class RiskAnalyzer:
             return best
         else:
             best = float("inf")
-            for mv in board.legal_moves:
-                if beta <= alpha:
+            legal = board.generate_legal_moves()
+            while beta > alpha:
+                try:
+                    mv = next(legal)
+                except StopIteration:
                     break
                 board.push(mv)
                 to_sq = mv.to_square

--- a/tests/test_risk_analyzer.py
+++ b/tests/test_risk_analyzer.py
@@ -40,7 +40,7 @@ def test_alpha_beta_prunes(monkeypatch):
             raise AssertionError("alpha-beta failed to prune")
         return original_push(move)
 
-    board.push = fake_push
+    monkeypatch.setattr(board, "push", fake_push)
 
     result = analyzer._search(board, 1, True, board.turn, alpha=-float("inf"), beta=0)
     assert result == 0


### PR DESCRIPTION
## Summary
- Stop `_search` from iterating past cut-offs by checking `alpha`/`beta` before requesting more moves
- Use `monkeypatch.setattr` to stub legal move generation and `push` in alpha-beta pruning test

## Testing
- `pytest tests/test_risk_analyzer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c041eebc83259d04869d1f0cecd7