### PR TITLE
Add date-based grouping and timestamps to game loader

### DIFF
--- a/analysis/loader.py
+++ b/analysis/loader.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Any, Dict, List
+
+REQUIRED_KEYS = {"moves", "fens", "modules_w", "modules_b", "result"}
+
+
+def load_runs(path: str) -> List[Dict[str, Any]]:
+    """Load run JSON files from *path* and include save timestamps.
+
+    Each JSON file must contain the keys defined in :data:`REQUIRED_KEYS`.
+    The returned run dictionaries additionally include a ``date`` field with
+    the file's modification time encoded via :meth:`datetime.isoformat`.
+    """
+    runs: List[Dict[str, Any]] = []
+    base_path = Path(path)
+
+    for file in sorted(base_path.glob("*.json")):
+        with file.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        missing = REQUIRED_KEYS - data.keys()
+        if missing:
+            raise ValueError(
+                f"Missing keys in {file.name}: {', '.join(sorted(missing))}"
+            )
+
+        runs.append(
+            {
+                "game_id": file.stem,
+                "moves": data["moves"],
+                "fens": data["fens"],
+                "modules_w": data["modules_w"],
+                "modules_b": data["modules_b"],
+                "result": data["result"],
+                "date": datetime.fromtimestamp(file.stat().st_mtime).isoformat(),
+            }
+        )
+
+    return runs

--- a/tests/test_game_list_panel.py
+++ b/tests/test_game_list_panel.py
@@ -4,6 +4,7 @@ import pytest
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 pytest.importorskip("PySide6")
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
 from ui.game_list_panel import GameListPanel, GameListModel
@@ -32,6 +33,26 @@ def test_sort_by_result_and_date():
 
     panel.sort_combo.setCurrentIndex(1)  # Run Date
     assert _visible_ids(panel) == ["g1", "g2", "g3"]
+    panel.close()
+
+
+def test_group_by_date():
+    app = QApplication.instance() or QApplication([])
+    runs = [
+        {"game_id": "g1", "result": "0-1", "date": "2024-01-03"},
+        {"game_id": "g2", "result": "1-0", "date": "2024-01-02"},
+        {"game_id": "g3", "result": "1/2-1/2", "date": "2024-01-03"},
+    ]
+    panel = GameListPanel(runs)
+    panel.group_checkbox.setChecked(True)
+    model = panel.tree_model
+    roots = [model.item(i).text() for i in range(model.rowCount())]
+    assert roots == ["2024-01-03", "2024-01-02"]
+    first_children = {
+        model.item(0).child(i).data(Qt.UserRole)["game_id"]
+        for i in range(model.item(0).rowCount())
+    }
+    assert first_children == {"g1", "g3"}
     panel.close()
 
 


### PR DESCRIPTION
## Summary
- include file modification timestamps when loading games
- allow grouping game list by date via a toggleable tree view
- test grouped and sorted listings

## Testing
- `pytest tests/test_game_list_panel.py -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c271bf3c8325a4fb43a6268f4fc8