### PR TITLE
Normalize piece colors when building board

### DIFF
--- a/core/piece.py
+++ b/core/piece.py
@@ -3,6 +3,16 @@ try:  # Optional dependency used only for advanced piece logic
 except Exception:  # pragma: no cover - chess may be absent in tests
     chess = None
 
+from .board import Board
+
+
+def _color_to_str(color):
+    """Return ``'white'`` or ``'black'`` for various color representations."""
+
+    if isinstance(color, str):
+        return color
+    return 'white' if color else 'black'
+
 class Piece:
     def __init__(self, color, position):
         self.color = color
@@ -174,4 +184,20 @@ def piece_class_factory(piece, pos):
     elif t == 'k':
         return King(piece.color, pos)
     return Piece(piece.color, pos)
+
+
+def _build_board(chess_board):
+    """Construct a project :class:`Board` from a python-chess board."""
+
+    board = Board()
+    if chess is None:  # pragma: no cover - python-chess is optional
+        return board
+
+    for square, p in chess_board.piece_map().items():
+        pos = (chess.square_rank(square), chess.square_file(square))
+        piece = piece_class_factory(p, pos)
+        piece.color = _color_to_str(piece.color)
+        board.place_piece(piece)
+
+    return board
 

--- a/tests/test_build_board_color.py
+++ b/tests/test_build_board_color.py
@@ -1,0 +1,15 @@
+import chess
+
+from core.piece import _build_board
+
+
+def test_build_board_preserves_white_color():
+    pc_board = chess.Board()
+    pc_board.clear()
+    pc_board.set_piece_at(chess.E4, chess.Piece(chess.KING, chess.WHITE))
+
+    board = _build_board(pc_board)
+
+    whites = board.get_pieces('white')
+    assert len(whites) == 1
+    assert whites[0].color == 'white'


### PR DESCRIPTION
## Summary
- Normalize piece color inputs for both strings and booleans
- Build boards with consistent color conversion from python-chess pieces
- Test that converting python-chess pieces preserves white color

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c5771d6c8325be8b878dcad79dee