### PR TITLE
Add defense map tests for knight and bishop

### DIFF
--- a/tests/test_board_analyzer_defense.py
+++ b/tests/test_board_analyzer_defense.py
@@ -1,13 +1,16 @@
 import chess
 
 from core.board_analyzer import BoardAnalyzer
-from .test_piece_attacks import make_piece
+from core.piece import piece_class_factory
 
 
 class WrappedBoard:
     def __init__(self, board: chess.Board):
         self.board = board
-        self.pieces = [make_piece(board, sq) for sq in board.piece_map()]
+        self.pieces = [
+            piece_class_factory(piece, (chess.square_rank(sq), chess.square_file(sq)))
+            for sq, piece in board.piece_map().items()
+        ]
 
     def attacks(self, square: int):
         return self.board.attacks(square)
@@ -30,3 +33,33 @@ def test_rook_defends_pawn_from_fen():
     defense_map = analyzer.get_defense_map()
     assert defense_map['white'] == {chess.D6}
     assert defense_map['black'] == set()
+
+
+def test_knight_defends_pawn_with_boolean_colors():
+    board = chess.Board()
+    board.clear()
+    board.set_piece_at(chess.D4, chess.Piece(chess.KNIGHT, chess.WHITE))
+    board.set_piece_at(chess.F5, chess.Piece(chess.PAWN, chess.WHITE))
+    board.set_piece_at(chess.E6, chess.Piece(chess.KNIGHT, chess.BLACK))
+    board.set_piece_at(chess.F4, chess.Piece(chess.PAWN, chess.BLACK))
+
+    wrapped = WrappedBoard(board)
+    analyzer = BoardAnalyzer(wrapped)
+    defense_map = analyzer.get_defense_map()
+    assert defense_map['white'] == {chess.F5}
+    assert defense_map['black'] == {chess.F4}
+
+
+def test_bishop_defends_pawn_with_boolean_colors():
+    board = chess.Board()
+    board.clear()
+    board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
+    board.set_piece_at(chess.F8, chess.Piece(chess.BISHOP, chess.BLACK))
+    board.set_piece_at(chess.E7, chess.Piece(chess.PAWN, chess.BLACK))
+
+    wrapped = WrappedBoard(board)
+    analyzer = BoardAnalyzer(wrapped)
+    defense_map = analyzer.get_defense_map()
+    assert defense_map['white'] == {chess.D2}
+    assert defense_map['black'] == {chess.E7}


### PR DESCRIPTION
## Summary
- expand defense tests to cover knight and bishop protecting allied pieces
- instantiate pieces via `piece_class_factory` to ensure boolean color handling

## Testing
- `pytest tests/test_board_analyzer_defense.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c818102883258e04b7878f26bb6a