### PR TITLE
docs: add R install steps and improve r bridge warnings

### DIFF
--- a/chess_ai/hybrid_bot/r_bridge.py
+++ b/chess_ai/hybrid_bot/r_bridge.py
@@ -12,6 +12,9 @@ try:  # pragma: no cover - optional dependency
     from rpy2 import robjects
 except Exception:  # rpy2 may be missing in lightweight environments
     robjects = None  # type: ignore
+    warnings.warn(
+        "R runtime or rpy2 is not available; install them to enable R evaluation.",
+    )
 
 
 _FUNC_NAME = "eval_position_complex"
@@ -27,6 +30,11 @@ def _ensure_loaded() -> None:
         warnings.warn("rpy2 or R is not installed; R evaluation disabled.")
         raise RuntimeError("rpy2 is not installed")
     script = Path(__file__).with_name(f"{_FUNC_NAME}.R")
+    if not script.exists():
+        warnings.warn(
+            f"R evaluation script '{script.name}' is missing; R evaluation disabled."
+        )
+        raise RuntimeError("missing R evaluation script")
     try:
         robjects.r["source"](str(script))
     except Exception as exc:

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -5,18 +5,22 @@ These metrics feed into the engine's evaluation and are available through `core.
 
 ## Setup
 
-Some evaluation helpers rely on an optional R bridge and PyTorch‑based models. To enable these features install the following dependencies:
+Some evaluation helpers rely on an optional R bridge and PyTorch‑based models.
+To enable these features install the following dependencies in order:
 
-1. **R runtime**
+1. **R runtime** – provides the interpreter required by `rpy2`.
    ```bash
-   sudo apt-get update && sudo apt-get install -y r-base
+   sudo apt-get update
+   sudo apt-get install -y r-base
    ```
-2. **rpy2 Python package**
+   After installation you can verify the setup with `R --version`.
+2. **`rpy2` Python package** – exposes R functions to Python.
    ```bash
    pip install rpy2
    ```
-3. **PyTorch and related packages**
-   Visit <https://pytorch.org/get-started/locally/> for platform-specific commands or use the CPU wheels:
+3. **PyTorch and related packages** – required for neural‑network evaluators.
+   Visit <https://pytorch.org/get-started/locally/> for platform-specific commands
+   or use the CPU wheels:
    ```bash
    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
    ```


### PR DESCRIPTION
## Summary
- document how to install R, rpy2 and PyTorch dependencies
- warn when R runtime or eval_position_complex.R script is missing

## Testing
- `pytest tests/test_random_bot.py tests/test_r_bridge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c9160d04832589d068619796da15