### PR TITLE
Optimize board analyzer by reusing single chess board

### DIFF
--- a/core/board_analyzer.py
+++ b/core/board_analyzer.py
@@ -1,11 +1,15 @@
+from .piece import build_chess_board
+
+
 class BoardAnalyzer:
     def __init__(self, board):
         self.board = board
 
     def get_all_attacks(self, color):
+        chess_board = build_chess_board(self.board)
         attacks = set()
         for piece in self.board.get_pieces(color):
-            squares = piece.get_attacked_squares(self.board)
+            squares = piece.get_attacked_squares(self.board, chess_board)
             attacks.update(squares)
         return attacks
 
@@ -17,8 +21,11 @@ class BoardAnalyzer:
     
     def get_defense_map(self):
         """Return mapping of color to defended squares on the board."""
+        chess_board = build_chess_board(self.board)
         defense_map = {'white': set(), 'black': set()}
         for color in ('white', 'black'):
             for piece in self.board.get_pieces(color):
-                defense_map[color].update(piece.get_defended_squares(self.board))
+                defense_map[color].update(
+                    piece.get_defended_squares(self.board, chess_board)
+                )
         return defense_map

--- a/core/piece.py
+++ b/core/piece.py
@@ -6,6 +6,14 @@ except Exception:  # pragma: no cover - chess may be absent in tests
 from .board import Board
 
 
+def _color_to_bool(color):
+    """Return ``True`` for white and ``False`` for black for various inputs."""
+
+    if isinstance(color, str):
+        return color == 'white'
+    return bool(color)
+
+
 def _color_to_str(color):
     """Return ``'white'`` or ``'black'`` for various color representations."""
 
@@ -54,7 +62,7 @@ class Piece:
         rank, file = self.position
         return chess.square(file, rank)
 
-    def get_attacked_squares(self, board):
+    def get_attacked_squares(self, board, chess_board=None):
         """Return squares this piece attacks using python-chess helpers."""
 
         if chess is None:  # pragma: no cover - defensive fallback
@@ -64,11 +72,12 @@ class Piece:
         if square is None:
             return set()
 
-        # ``board.attacks`` is provided by python-chess; for custom board
-        # implementations the method is expected to mirror this behaviour.
-        return set(board.attacks(square))
+        cb = chess_board or (
+            board if hasattr(board, "attacks") else build_chess_board(board)
+        )
+        return set(cb.attacks(square))
 
-    def get_defended_squares(self, board):
+    def get_defended_squares(self, board, chess_board=None):
         """Return squares defended by this piece.
 
         A defended square is one that the piece attacks but is occupied by a
@@ -79,10 +88,14 @@ class Piece:
         if chess is None:  # pragma: no cover - defensive fallback
             return set()
 
+        cb = chess_board or (
+            board if hasattr(board, "piece_at") else build_chess_board(board)
+        )
         defended = set()
-        for sq in self.get_attacked_squares(board):
-            piece = board.piece_at(sq)
-            if piece and piece.color == self.color:
+        self_color = _color_to_bool(self.color)
+        for sq in self.get_attacked_squares(board, chess_board=cb):
+            piece = cb.piece_at(sq)
+            if piece and piece.color == self_color:
                 defended.add(sq)
         return defended
 
@@ -93,16 +106,20 @@ class Pawn(Piece):
 class Rook(Piece):
     def __init__(self, color, position):
         super().__init__(color, position)
-    def update_defended(self, board):
+    def update_defended(self, board, chess_board=None):
         """Populate ``defended_moves`` and ``attacked_moves`` overlays."""
         self.defended_moves.clear()
         self.attacked_moves.clear()
 
-        for sq in self.get_attacked_squares(board):
-            piece = board.piece_at(sq)
+        cb = chess_board or (
+            board if hasattr(board, "piece_at") else build_chess_board(board)
+        )
+
+        for sq in self.get_attacked_squares(board, chess_board=cb):
+            piece = cb.piece_at(sq)
             if piece is None:
                 continue
-            if piece.color == self.color:
+            if piece.color == _color_to_bool(self.color):
                 self.defended_moves.add(sq)
             else:
                 self.attacked_moves.add(sq)
@@ -110,12 +127,15 @@ class Rook(Piece):
 class Knight(Piece):
     def __init__(self, color, position):
         super().__init__(color, position)
-    def update_fork(self, board):
+    def update_fork(self, board, chess_board=None):
+        cb = chess_board or (
+            board if hasattr(board, "piece_at") else build_chess_board(board)
+        )
         self.fork_moves.clear()
         fork_targets = []
-        for sq in self.get_attacked_squares(board):
-            piece = board.piece_at(sq)
-            if piece and piece.color != self.color and piece.piece_type in [chess.QUEEN, chess.ROOK, chess.KING]:
+        for sq in self.get_attacked_squares(board, chess_board=cb):
+            piece = cb.piece_at(sq)
+            if piece and piece.color != _color_to_bool(self.color) and piece.piece_type in [chess.QUEEN, chess.ROOK, chess.KING]:
                 fork_targets.append(sq)
         if len(fork_targets) >= 2:
             self.fork_moves.update(fork_targets)
@@ -127,43 +147,53 @@ class Bishop(Piece):
 class Queen(Piece):
     def __init__(self, color, position):
         super().__init__(color, position)
-    def update_hanging(self, board):
+    def update_hanging(self, board, chess_board=None):
+        cb = chess_board or (
+            board if hasattr(board, "piece_at") else build_chess_board(board)
+        )
         self.hanging_targets.clear()
-        for sq in self.get_attacked_squares(board):
-            piece = board.piece_at(sq)
-            if piece and piece.color != self.color:
-                defenders = board.attackers(not self.color, sq)
+        for sq in self.get_attacked_squares(board, chess_board=cb):
+            piece = cb.piece_at(sq)
+            if piece and piece.color != _color_to_bool(self.color):
+                defenders = cb.attackers(not _color_to_bool(self.color), sq)
                 if not defenders:
                     self.hanging_targets.add(sq)
-    def update_pin_and_check(self, board):
+
+    def update_pin_and_check(self, board, chess_board=None):
+        cb = chess_board or (
+            board if hasattr(board, "piece_at") else build_chess_board(board)
+        )
         self.pin_moves.clear()
         self.check_squares.clear()
-        attacks = self.get_attacked_squares(board)
+        attacks = self.get_attacked_squares(board, chess_board=cb)
         queen_sq = self._as_square()
         for sq in attacks:
-            piece = board.piece_at(sq)
-            if piece and piece.color != self.color and piece.piece_type != chess.KING:
-                ksq = board.king(not self.color)
+            piece = cb.piece_at(sq)
+            if piece and piece.color != _color_to_bool(self.color) and piece.piece_type != chess.KING:
+                ksq = cb.king(not _color_to_bool(self.color))
                 if ksq is not None:
                     rq, rf = chess.square_rank(sq), chess.square_file(sq)
                     kr, kf = chess.square_rank(ksq), chess.square_file(ksq)
                     qr, qf = self.position
                     if rq == kr or rf == kf or abs(rq - kr) == abs(rf - kf):
                         self.pin_moves.add(sq)
-        king_sq = board.king(not self.color)
+        king_sq = cb.king(not _color_to_bool(self.color))
         if king_sq and king_sq in attacks:
             self.check_squares.add(king_sq)
 
 class King(Piece):
     def __init__(self, color, position):
         super().__init__(color, position)
-    def update_king_moves(self, board):
+    def update_king_moves(self, board, chess_board=None):
+        cb = chess_board or (
+            board if hasattr(board, "legal_moves") else build_chess_board(board)
+        )
         self.safe_moves.clear()
         self.attacked_moves.clear()
         king_sq = self._as_square()
-        for move in board.legal_moves:
+        for move in cb.legal_moves:
             if move.from_square == king_sq:
-                attackers = board.attackers(not self.color, move.to_square)
+                attackers = cb.attackers(not _color_to_bool(self.color), move.to_square)
                 if attackers:
                     self.attacked_moves.add(move.to_square)
                 else:
@@ -200,4 +230,44 @@ def _build_board(chess_board):
         board.place_piece(piece)
 
     return board
+
+
+def build_chess_board(board):
+    """Construct a :class:`chess.Board` from a project board-like object."""
+
+    if chess is None:  # pragma: no cover - chess may be absent in tests
+        return None
+
+    if isinstance(board, chess.Board):
+        return board
+
+    if hasattr(board, "board") and isinstance(board.board, chess.Board):
+        return board.board
+
+    cb = chess.Board()
+    cb.clear()
+    for piece in board.get_pieces():
+        pos = piece.position
+        if isinstance(pos, str):
+            square = chess.parse_square(pos)
+        else:
+            r, f = pos
+            square = chess.square(f, r)
+        color = chess.WHITE if _color_to_bool(piece.color) else chess.BLACK
+        if isinstance(piece, Pawn):
+            ptype = chess.PAWN
+        elif isinstance(piece, Rook):
+            ptype = chess.ROOK
+        elif isinstance(piece, Knight):
+            ptype = chess.KNIGHT
+        elif isinstance(piece, Bishop):
+            ptype = chess.BISHOP
+        elif isinstance(piece, Queen):
+            ptype = chess.QUEEN
+        elif isinstance(piece, King):
+            ptype = chess.KING
+        else:
+            continue
+        cb.set_piece_at(square, chess.Piece(ptype, color))
+    return cb
 

--- a/tests/test_board_analyzer_single_build.py
+++ b/tests/test_board_analyzer_single_build.py
@@ -1,0 +1,42 @@
+import chess
+import core.piece as piece
+import core.board_analyzer as ba
+
+
+def test_get_all_attacks_builds_board_once(monkeypatch):
+    base = chess.Board()
+    base.clear()
+    base.set_piece_at(chess.D4, chess.Piece(chess.ROOK, chess.WHITE))
+    board = piece._build_board(base)
+    analyzer = ba.BoardAnalyzer(board)
+
+    calls = {'n': 0}
+    original = ba.build_chess_board
+
+    def wrapper(b):
+        calls['n'] += 1
+        return original(b)
+
+    monkeypatch.setattr(ba, 'build_chess_board', wrapper)
+    attacks = analyzer.get_all_attacks('white')
+    assert attacks == set(base.attacks(chess.D4))
+    assert calls['n'] == 1
+
+
+def test_get_defense_map_builds_board_once(monkeypatch):
+    base = chess.Board("k7/8/3P4/8/3R4/8/8/K7 w - - 0 1")
+    board = piece._build_board(base)
+    analyzer = ba.BoardAnalyzer(board)
+
+    calls = {'n': 0}
+    original = ba.build_chess_board
+
+    def wrapper(b):
+        calls['n'] += 1
+        return original(b)
+
+    monkeypatch.setattr(ba, 'build_chess_board', wrapper)
+    defense_map = analyzer.get_defense_map()
+    assert defense_map['white'] == {chess.D6}
+    assert defense_map['black'] == set()
+    assert calls['n'] == 1


### PR DESCRIPTION
## Summary
- Build a python-chess board only once per analysis and reuse it across piece evaluations
- Allow piece helpers to accept a pre-built `chess.Board` or build one from project boards
- Add regression tests confirming single board construction for attack and defense calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ca82c0088325b75134e845a1ba90