### PR TITLE
Vendored PySide6 stubs for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,18 @@
 import sys
 from pathlib import Path
 
-# Ensure vendored dependencies are importable by adding the ``vendors/chess``
-# directory to ``sys.path`` before any other imports occur and verifying it is
-# inserted ahead of other locations.
-vendor_path = Path(__file__).resolve().parents[1] / "vendors" / "chess"
-sys.path.insert(0, str(vendor_path))
-assert sys.path[0] == str(vendor_path)
+# ``vendors/`` contains all third-party libraries bundled with the project.
+# Prepend it to ``sys.path`` so modules like ``PySide6`` can be imported
+# without being globally installed.  We still ensure that the vendored
+# ``chess`` package takes precedence over any site-wide installation by
+# explicitly putting ``vendors/chess`` at the very front of the path.
+vendor_root = Path(__file__).resolve().parents[1] / "vendors"
+sys.path.insert(0, str(vendor_root))
+assert sys.path[0] == str(vendor_root)
+
+chess_vendor = vendor_root / "chess"
+sys.path.insert(0, str(chess_vendor))
+assert sys.path[0] == str(chess_vendor)
 
 import chess
 import pytest

--- a/vendors/PySide6/QtCore.py
+++ b/vendors/PySide6/QtCore.py
@@ -1,0 +1,129 @@
+"""Minimal stub implementations of PySide6.QtCore classes used in tests.
+This is not a full-featured Qt binding but provides just enough
+functionality for the project's unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cmp_to_key
+from typing import Any, Callable, List, Optional
+
+
+class Qt:
+    """Subset of the Qt enum values used by the project."""
+
+    DisplayRole = 0
+    UserRole = 256
+    AscendingOrder = 0
+    DescendingOrder = 1
+
+
+class Signal:
+    """Very small replacement for Qt's signal/slot mechanism."""
+
+    def __init__(self) -> None:
+        self._slots: List[Callable[..., None]] = []
+
+    def connect(self, slot: Callable[..., None]) -> None:
+        self._slots.append(slot)
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        for slot in list(self._slots):
+            slot(*args, **kwargs)
+
+
+@dataclass
+class QModelIndex:
+    """Simple stand-in for QModelIndex handling only row access."""
+
+    _row: Optional[int] = None
+
+    def row(self) -> int:
+        return -1 if self._row is None else self._row
+
+    def isValid(self) -> bool:  # pragma: no cover - trivial
+        return self._row is not None
+
+
+class QAbstractListModel:
+    """Base class implementing minimal Qt model behaviour."""
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # pragma: no cover - interface only
+        return 0
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # pragma: no cover - interface only
+        return None
+
+    # Qt models use begin/endResetModel around data resets; here they are
+    # simple no-ops so the API is compatible with the real library.
+    def beginResetModel(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def endResetModel(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class QSortFilterProxyModel(QAbstractListModel):
+    """Very small proxy model supporting custom ``lessThan`` sorting."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._source_model: Optional[QAbstractListModel] = None
+        self._rows: List[int] = []
+
+    # --------------------------------------------------------------
+    def setSourceModel(self, model: QAbstractListModel) -> None:
+        self._source_model = model
+        self.invalidate()
+
+    # --------------------------------------------------------------
+    def sourceModel(self) -> Optional[QAbstractListModel]:  # pragma: no cover - trivial
+        return self._source_model
+
+    # --------------------------------------------------------------
+    def invalidate(self) -> None:
+        if self._source_model is not None:
+            self._rows = list(range(self._source_model.rowCount()))
+        else:
+            self._rows = []
+
+    # --------------------------------------------------------------
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        return len(self._rows)
+
+    # --------------------------------------------------------------
+    def index(self, row: int, column: int) -> QModelIndex:
+        if 0 <= row < len(self._rows):
+            return QModelIndex(self._rows[row])
+        return QModelIndex()
+
+    # --------------------------------------------------------------
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):
+        if self._source_model is None or not index.isValid():
+            return None
+        return self._source_model.data(QModelIndex(index.row()), role)
+
+    # --------------------------------------------------------------
+    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:  # pragma: no cover - overridden in subclass
+        return left.row() < right.row()
+
+    # --------------------------------------------------------------
+    def sort(self, column: int, order: int = Qt.AscendingOrder) -> None:
+        if self._source_model is None:
+            self._rows = []
+            return
+
+        def cmp(l: int, r: int) -> int:
+            li = QModelIndex(l)
+            ri = QModelIndex(r)
+            if self.lessThan(li, ri):
+                return -1
+            if self.lessThan(ri, li):
+                return 1
+            return 0
+
+        self._rows = list(range(self._source_model.rowCount()))
+        self._rows.sort(key=cmp_to_key(cmp))
+        if order == Qt.DescendingOrder:
+            self._rows.reverse()

--- a/vendors/PySide6/QtGui.py
+++ b/vendors/PySide6/QtGui.py
@@ -1,0 +1,64 @@
+"""Minimal stubs for PySide6.QtGui used in tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .QtCore import Qt
+
+
+class QStandardItem:
+    def __init__(self, text: str = "") -> None:
+        self._text = text
+        self._data: Dict[int, Any] = {}
+        self._children: List[QStandardItem] = []
+
+    # --------------------------------------------------------------
+    def appendRow(self, item: "QStandardItem") -> None:
+        self._children.append(item)
+
+    # --------------------------------------------------------------
+    def text(self) -> str:  # pragma: no cover - trivial
+        return self._text
+
+    # --------------------------------------------------------------
+    def setData(self, value: Any, role: int) -> None:
+        self._data[role] = value
+
+    # --------------------------------------------------------------
+    def data(self, role: int) -> Any:
+        return self._data.get(role)
+
+    # --------------------------------------------------------------
+    def child(self, row: int) -> "QStandardItem":
+        return self._children[row]
+
+    # --------------------------------------------------------------
+    def rowCount(self) -> int:
+        return len(self._children)
+
+
+class QStandardItemModel:
+    def __init__(self) -> None:
+        self._roots: List[QStandardItem] = []
+        self._headers: List[str] = []
+
+    # --------------------------------------------------------------
+    def clear(self) -> None:
+        self._roots.clear()
+
+    # --------------------------------------------------------------
+    def setHorizontalHeaderLabels(self, labels: List[str]) -> None:  # pragma: no cover - trivial
+        self._headers = list(labels)
+
+    # --------------------------------------------------------------
+    def appendRow(self, item: QStandardItem) -> None:
+        self._roots.append(item)
+
+    # --------------------------------------------------------------
+    def rowCount(self) -> int:
+        return len(self._roots)
+
+    # --------------------------------------------------------------
+    def item(self, row: int) -> QStandardItem:
+        return self._roots[row]

--- a/vendors/PySide6/QtWidgets.py
+++ b/vendors/PySide6/QtWidgets.py
@@ -1,0 +1,112 @@
+"""Minimal QtWidgets stubs for headless testing."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from .QtCore import Qt, Signal
+
+
+class QApplication:
+    _instance: Optional["QApplication"] = None
+
+    def __init__(self, args: List[str]) -> None:  # pragma: no cover - trivial
+        QApplication._instance = self
+
+    @staticmethod
+    def instance() -> Optional["QApplication"]:  # pragma: no cover - trivial
+        return QApplication._instance
+
+    def exec(self) -> int:  # pragma: no cover - trivial
+        return 0
+
+
+class QWidget:
+    def __init__(self, parent: Optional["QWidget"] = None) -> None:  # pragma: no cover - trivial
+        self._visible = True
+        self._layout: Optional[Any] = None
+
+    def setVisible(self, visible: bool) -> None:
+        self._visible = visible
+
+    def isVisible(self) -> bool:  # pragma: no cover - trivial
+        return self._visible
+
+    def setLayout(self, layout: Any) -> None:  # pragma: no cover - trivial
+        self._layout = layout
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class QListView(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model: Any = None
+
+    def setModel(self, model: Any) -> None:
+        self.model = model
+
+
+class QTreeView(QListView):
+    def setModel(self, model: Any) -> None:
+        self.model = model
+
+    def setHeaderHidden(self, hidden: bool) -> None:  # pragma: no cover - trivial
+        self._header_hidden = hidden
+
+    def hide(self) -> None:
+        self.setVisible(False)
+
+
+class QVBoxLayout:
+    def __init__(self, parent: Optional[QWidget] = None) -> None:  # pragma: no cover - trivial
+        self._items: List[Any] = []
+        if parent is not None:
+            parent.setLayout(self)
+
+    def addWidget(self, widget: Any) -> None:
+        self._items.append(widget)
+
+    def addLayout(self, layout: "QVBoxLayout") -> None:
+        self._items.append(layout)
+
+
+class QHBoxLayout(QVBoxLayout):
+    pass
+
+
+class QComboBox(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self._items: List[tuple[str, Any]] = []
+        self._current_index = 0
+        self.currentIndexChanged = Signal()
+
+    def addItem(self, text: str, userData: Any = None) -> None:
+        self._items.append((text, userData))
+
+    def itemData(self, index: int) -> Any:
+        return self._items[index][1]
+
+    def setCurrentIndex(self, index: int) -> None:
+        self._current_index = index
+        self.currentIndexChanged.emit(index)
+
+    def currentIndex(self) -> int:  # pragma: no cover - trivial
+        return self._current_index
+
+
+class QCheckBox(QWidget):
+    def __init__(self, text: str = "") -> None:
+        super().__init__()
+        self.text = text
+        self._checked = False
+        self.toggled = Signal()
+
+    def setChecked(self, checked: bool) -> None:
+        self._checked = checked
+        self.toggled.emit(checked)
+
+    def isChecked(self) -> bool:  # pragma: no cover - trivial
+        return self._checked

--- a/vendors/PySide6/__init__.py
+++ b/vendors/PySide6/__init__.py
@@ -1,0 +1,3 @@
+from . import QtCore, QtGui, QtWidgets
+
+__all__ = ['QtCore', 'QtGui', 'QtWidgets']


### PR DESCRIPTION
## Summary
- add minimal PySide6 implementation under vendors for headless UI tests
- insert vendors path into tests sys.path to expose vendored libraries

## Testing
- `pytest tests/test_game_list_panel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cbcc165483258116bc101f03ba36