### PR TITLE
Reuse chess board in piece analysis

### DIFF
--- a/core/board_analyzer.py
+++ b/core/board_analyzer.py
@@ -9,7 +9,7 @@ class BoardAnalyzer:
         chess_board = build_chess_board(self.board)
         attacks = set()
         for piece in self.board.get_pieces(color):
-            squares = piece.get_attacked_squares(self.board, chess_board)
+            squares = piece.get_attacked_squares(chess_board=chess_board)
             attacks.update(squares)
         return attacks
 
@@ -26,6 +26,6 @@ class BoardAnalyzer:
         for color in ('white', 'black'):
             for piece in self.board.get_pieces(color):
                 defense_map[color].update(
-                    piece.get_defended_squares(self.board, chess_board)
+                    piece.get_defended_squares(chess_board=chess_board)
                 )
         return defense_map

--- a/tests/test_piece_attacks.py
+++ b/tests/test_piece_attacks.py
@@ -1,5 +1,7 @@
 import chess
 
+import core.piece as piece
+
 from core.piece import piece_class_factory
 
 
@@ -26,3 +28,40 @@ def test_knight_attacks_match_board_attacks():
     board.set_piece_at(sq, chess.Piece(chess.KNIGHT, chess.WHITE))
     knight = make_piece(board, sq)
     assert knight.get_attacked_squares(board) == set(board.attacks(sq))
+
+
+def test_get_attacked_squares_uses_prebuilt_board(monkeypatch):
+    board = chess.Board()
+    board.clear()
+    sq = chess.D4
+    board.set_piece_at(sq, chess.Piece(chess.ROOK, chess.WHITE))
+    rook = make_piece(board, sq)
+
+    calls = {'n': 0}
+    original = piece.build_chess_board
+
+    def wrapper(b):
+        calls['n'] += 1
+        return original(b)
+
+    monkeypatch.setattr(piece, 'build_chess_board', wrapper)
+    attacked = rook.get_attacked_squares(chess_board=board)
+    assert attacked == set(board.attacks(sq))
+    assert calls['n'] == 0
+
+
+def test_get_defended_squares_uses_prebuilt_board(monkeypatch):
+    base = chess.Board("k7/8/3P4/8/3R4/8/8/K7 w - - 0 1")
+    rook = make_piece(base, chess.D4)
+
+    calls = {'n': 0}
+    original = piece.build_chess_board
+
+    def wrapper(b):
+        calls['n'] += 1
+        return original(b)
+
+    monkeypatch.setattr(piece, 'build_chess_board', wrapper)
+    defended = rook.get_defended_squares(chess_board=base)
+    assert defended == {chess.D6}
+    assert calls['n'] == 0


### PR DESCRIPTION
## Summary
- Avoid rebuilding python-chess boards inside piece methods by accepting optional pre-built boards.
- Pass a single constructed board through `BoardAnalyzer` when computing attack and defense maps.
- Add tests ensuring pre-built boards are reused and functionality remains unchanged.

## Testing
- `pytest tests/test_piece_attacks.py tests/test_board_analyzer_single_build.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cdcb75288325b7e92ecad801cdcf