### PR TITLE
Refactor attacked squares metric interface

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -1,8 +1,10 @@
+from typing import List
+
 import chess
 
 
-def calculate_attacked_squares(piece: chess.Piece, board: chess.Board) -> list[int]:
-    """Calculate squares ``piece`` attacks on ``board``.
+def calculate_attacked_squares(board: chess.Board, square: int) -> List[int]:
+    """Calculate squares a piece on ``square`` attacks on ``board``.
 
     The function is a light wrapper around :meth:`chess.Board.attacks`.
     ``Board.attacks`` returns a :class:`chess.SquareSet`, which is converted
@@ -11,27 +13,24 @@ def calculate_attacked_squares(piece: chess.Piece, board: chess.Board) -> list[i
 
     Parameters
     ----------
-    piece:
-        The :class:`chess.Piece` whose attacks are being calculated.  The
-        function verifies that this piece exists on ``board``.
     board:
         The current :class:`chess.Board` instance.
+    square:
+        The integer index of the square from which to calculate attacks.
 
     Returns
     -------
-    list[int]
-        Squares (as integers) that ``piece`` attacks.
+    List[int]
+        Squares (as integers) that the piece on ``square`` attacks.
 
     Raises
     ------
     ValueError
-        If ``piece`` is not present on ``board``.
+        If there is no piece on ``square``.
     """
 
-    piece_squares: chess.SquareSet = board.pieces(piece.piece_type, piece.color)
-    if not piece_squares:
-        raise ValueError(f"{piece} is not on the board")
+    if board.piece_at(square) is None:
+        raise ValueError(f"no piece at square {square}")
 
-    piece_square = next(iter(piece_squares))
-    attacked_squares: chess.SquareSet = board.attacks(piece_square)
+    attacked_squares: chess.SquareSet = board.attacks(square)
     return list(attacked_squares)

--- a/tests/test_attacked_squares.py
+++ b/tests/test_attacked_squares.py
@@ -11,7 +11,7 @@ def test_attacked_squares() -> None:
     piece = chess.Piece(chess.ROOK, chess.WHITE)
     board.set_piece_at(square, piece)
 
-    result = calculate_attacked_squares(piece, board)
+    result = calculate_attacked_squares(board, square)
     expected = list(board.attacks(square))
 
     assert result == expected
@@ -19,11 +19,10 @@ def test_attacked_squares() -> None:
 
 
 def test_calculate_attacked_squares_missing_piece_raises_value_error() -> None:
-    """``calculate_attacked_squares`` raises ``ValueError`` if the piece is absent."""
+    """``calculate_attacked_squares`` raises ``ValueError`` if the square is empty."""
     board = chess.Board()
     board.clear()
-    missing_piece = chess.Piece(chess.BISHOP, chess.WHITE)
+    square = chess.E1
 
     with pytest.raises(ValueError):
-        calculate_attacked_squares(missing_piece, board)
-
+        calculate_attacked_squares(board, square)


### PR DESCRIPTION
## Summary
- Refactor `calculate_attacked_squares` to take a board and square and verify a piece exists
- Use `board.attacks` directly and return attacked squares as a list of integers
- Adjust tests for the new interface

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4bcbf288325a4a56c2fd5d99743