### PR TITLE
Refactor attacked squares tests

### DIFF
--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -5,17 +5,14 @@ from metrics.attacked_squares import calculate_attacked_squares
 
 def test_attacked_squares() -> None:
     """Verify the number of squares a rook attacks."""
-    board = chess.Board()
-    board.clear()
+    board = chess.Board("8/8/8/8/8/8/8/4R3 w - - 0 1")
     square = chess.E1
-    piece = chess.Piece(chess.ROOK, chess.WHITE)
-    board.set_piece_at(square, piece)
 
     result = calculate_attacked_squares(board, square)
     expected = list(board.attacks(square))
 
     assert result == expected
-    assert len(result) == 14  # Rook on e1 on an otherwise empty board
+    assert len(result) == 14  # Rook on e1 on an otherwise empty board  
 
 
 def test_calculate_attacked_squares_missing_piece_raises_value_error() -> None:
@@ -26,3 +23,12 @@ def test_calculate_attacked_squares_missing_piece_raises_value_error() -> None:
 
     with pytest.raises(ValueError):
         calculate_attacked_squares(board, square)
+
+
+def test_calculate_attacked_squares_empty_e2_raises_value_error() -> None:
+    """``calculate_attacked_squares`` raises ``ValueError`` if E2 is empty."""
+    board = chess.Board()
+    board.clear()
+
+    with pytest.raises(ValueError):
+        calculate_attacked_squares(board, chess.E2)


### PR DESCRIPTION
## Summary
- update attacked squares tests to use square index constants
- add validation that empty E2 square triggers `ValueError`

## Testing
- `pytest metrics/test_attacked_squares.py -q` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d6863d9c8325a75c5f581d8c85dc