### PR TITLE
Use optional R evaluation

### DIFF
--- a/chess_ai/hybrid_bot/orchestrator.py
+++ b/chess_ai/hybrid_bot/orchestrator.py
@@ -16,14 +16,19 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
 import chess
+import os
 
 from .alpha_beta import search as ab_search
 from .mcts import BatchMCTS
 from .evaluation import evaluate_position
 
-try:  # optional R evaluation
-    from .r_bridge import eval_board
-except Exception:  # pragma: no cover - rpy2 may be absent
+_USE_R = os.getenv("CHESS_USE_R") == "1"
+if _USE_R:
+    try:  # optional R evaluation
+        from .r_bridge import eval_board
+    except Exception:  # pragma: no cover - rpy2 may be absent
+        eval_board = None  # type: ignore
+else:  # R evaluation disabled
     eval_board = None  # type: ignore
 
 

--- a/tests/test_r_bridge.py
+++ b/tests/test_r_bridge.py
@@ -1,12 +1,39 @@
+"""Tests for the optional R evaluation bridge."""
+
+import importlib
+import sys
+import warnings
+
 import chess
 import pytest
 
-rpy2 = pytest.importorskip("rpy2")
 
-from chess_ai.hybrid_bot.r_bridge import eval_board
+def test_import_without_r_no_warning(monkeypatch):
+    """Importing r_bridge without rpy2 should not emit warnings."""
+    monkeypatch.setitem(sys.modules, "rpy2", None)
+    sys.modules.pop("chess_ai.hybrid_bot.r_bridge", None)
+    with warnings.catch_warnings(record=True) as caught:
+        rb = importlib.import_module("chess_ai.hybrid_bot.r_bridge")
+    assert caught == []
+    with pytest.raises(RuntimeError):
+        rb.eval_board(chess.Board())
 
 
-def test_eval_board_returns_float():
-    board = chess.Board()
-    score = eval_board(board)
+def test_orchestrator_falls_back(monkeypatch):
+    """HybridOrchestrator should fall back to Python eval when R is disabled."""
+    monkeypatch.delenv("CHESS_USE_R", raising=False)
+    import chess_ai.hybrid_bot.orchestrator as orch
+    importlib.reload(orch)
+    monkeypatch.setattr(orch, "evaluate_position", lambda b: 42.0)
+    o = orch.HybridOrchestrator(chess.WHITE)
+    assert o._r_eval(chess.Board()) == 42.0
+
+
+def test_eval_board_returns_float_when_r_available():
+    """If rpy2 is present the bridge should return a float score."""
+    pytest.importorskip("rpy2")
+    import chess_ai.hybrid_bot.r_bridge as rb
+    importlib.reload(rb)
+    score = rb.eval_board(chess.Board())
     assert isinstance(score, float)
+


### PR DESCRIPTION
## Summary
- swap warning-based R bridge for logging and raise on demand
- gate R evaluation in HybridOrchestrator behind `CHESS_USE_R`
- add tests for fallback behaviour and optional R evaluation

## Testing
- `pytest tests/test_r_bridge.py -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement python-chess)*

------
https://chatgpt.com/codex/tasks/task_e_689c46c9ba508325b32ec7e4ae146263