### PR TITLE
feat: bootstrap vendored dependencies

### DIFF
--- a/chess_ai/__main__.py
+++ b/chess_ai/__main__.py
@@ -1,0 +1,14 @@
+from vendors import setup_path  # noqa: F401
+
+
+def main() -> None:
+    """Package entry point used with ``python -m chess_ai``.
+
+    Importing :mod:`vendors.setup_path` ensures vendored third-party
+    dependencies are available on ``sys.path`` before other imports occur.
+    """
+    print("Chess AI package does not define a CLI by default.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,3 +11,5 @@ import sys
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, PROJECT_ROOT)
 
+from vendors import setup_path  # noqa: F401
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,4 @@
-import sys
-from pathlib import Path
-
-# ``vendors/`` contains all third-party libraries bundled with the project.
-# Prepend it to ``sys.path`` so modules like ``PySide6`` can be imported
-# without being globally installed.
-vendor_root = Path(__file__).resolve().parents[1] / "vendors"
-sys.path.insert(0, str(vendor_root))
-assert sys.path[0] == str(vendor_root)
+from vendors import setup_path  # noqa: F401
 
 import chess
 import pytest

--- a/tests/run_hybrid_demo.py
+++ b/tests/run_hybrid_demo.py
@@ -10,9 +10,8 @@ import sys
 import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "vendors"))
-)
+
+from vendors import setup_path  # noqa: F401
 
 import chess
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,3 +1,5 @@
+from vendors import setup_path  # noqa: F401
+
 from core.board import Board
 from core.piece import Pawn, Knight
 from core.board_analyzer import BoardAnalyzer

--- a/tests/test_game_list_panel.py
+++ b/tests/test_game_list_panel.py
@@ -1,3 +1,5 @@
+from vendors import setup_path  # noqa: F401
+
 import os
 import pytest
 

--- a/tests/test_load_runs.py
+++ b/tests/test_load_runs.py
@@ -1,3 +1,5 @@
+from vendors import setup_path  # noqa: F401
+
 import json
 import os
 import tempfile

--- a/tests/test_module_usage.py
+++ b/tests/test_module_usage.py
@@ -1,3 +1,5 @@
+from vendors import setup_path  # noqa: F401
+
 from utils.module_usage import aggregate_module_usage
 
 

--- a/tests/test_run_selector_window.py
+++ b/tests/test_run_selector_window.py
@@ -1,3 +1,5 @@
+from vendors import setup_path  # noqa: F401
+
 import os
 import pytest
 

--- a/vendors/setup_path.py
+++ b/vendors/setup_path.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+# Directory containing vendored third-party packages.
+VENDOR_DIR = Path(__file__).resolve().parent
+
+# Ensure the vendor directory itself has import precedence so packages like
+# ``chess`` can be imported directly from ``vendors/``.
+sys.path.insert(0, str(VENDOR_DIR))
+
+# Add wheel or archive files contained within the vendor directory.
+for entry in VENDOR_DIR.iterdir():
+    if entry.name == "setup_path.py":
+        continue
+    if entry.suffix in {".whl", ".zip"} or entry.name.endswith((".tar.gz", ".tar")):
+        sys.path.insert(0, str(entry))


### PR DESCRIPTION
## Summary
- add `vendors/setup_path.py` to prepend vendored packages to `sys.path`
- ensure tests and `chess_ai` entry point load vendored libraries automatically

## Testing
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc87dc5c83259f92a5b8303d0322