### PR TITLE
Validate piece presence before computing attacks

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -29,8 +29,10 @@ def calculate_attacked_squares(board: chess.Board, square: int) -> List[int]:
         If there is no piece on ``square``.
     """
 
-    if board.piece_at(square) is None:
+    piece = board.piece_at(square)
+    if piece is None or square not in board.pieces(piece.piece_type, piece.color):
         raise ValueError(f"no piece at square {square}")
 
-    attacked_squares: chess.SquareSet = board.attacks(square)
+    piece_square = square
+    attacked_squares: chess.SquareSet = board.attacks(piece_square)
     return list(attacked_squares)


### PR DESCRIPTION
## Summary
- ensure `calculate_attacked_squares` verifies the piece exists on the board using `board.pieces`
- raise `ValueError` when the target square is empty

## Testing
- `PYTHONPATH=vendors pytest metrics/test_attacked_squares.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5e005bb9483259d347b023e90e6a3