### PR TITLE
Add simple PyTorch model and network configuration

### DIFF
--- a/chess_ai/nn/__init__.py
+++ b/chess_ai/nn/__init__.py
@@ -1,0 +1,5 @@
+"""Neural network utilities for chess_ai."""
+
+from .torch_net import TorchNet
+
+__all__ = ["TorchNet"]

--- a/chess_ai/nn/simple_model.py
+++ b/chess_ai/nn/simple_model.py
@@ -1,0 +1,74 @@
+"""Simple feed-forward neural network for chess positions.
+
+This module defines :class:`SimpleChessModel`, a tiny PyTorch network that
+produces policy and value outputs for a given board. It is intentionally
+small and meant for tests and prototyping rather than playing strength.
+"""
+
+from __future__ import annotations
+
+import chess
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+INPUT_DIM = 773  # 12 * 64 board planes + 5 auxiliary features
+POLICY_DIM = 64 * 64  # from-square x to-square
+
+
+# ---------------------------------------------------------------------------
+# Board encoding
+# ---------------------------------------------------------------------------
+
+def board_to_tensor(board: chess.Board) -> torch.Tensor:
+    """Encode ``board`` into a flat tensor of size :data:`INPUT_DIM`."""
+    planes = torch.zeros(12, 8, 8, dtype=torch.float32)
+    for square, piece in board.piece_map().items():
+        idx = piece.piece_type - 1 + (0 if piece.color == chess.WHITE else 6)
+        planes[idx, square // 8, square % 8] = 1.0
+    flat = planes.view(-1)
+    extras = torch.tensor(
+        [
+            1.0 if board.turn == chess.WHITE else 0.0,
+            1.0 if board.has_kingside_castling_rights(chess.WHITE) else 0.0,
+            1.0 if board.has_queenside_castling_rights(chess.WHITE) else 0.0,
+            1.0 if board.has_kingside_castling_rights(chess.BLACK) else 0.0,
+            1.0 if board.has_queenside_castling_rights(chess.BLACK) else 0.0,
+        ],
+        dtype=torch.float32,
+    )
+    return torch.cat([flat, extras])
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+class SimpleChessModel(nn.Module):
+    """Very small fully connected network with policy and value heads."""
+
+    def __init__(self, hidden: int = 128) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(INPUT_DIM, hidden)
+        self.fc_policy = nn.Linear(hidden, POLICY_DIM)
+        self.fc_value = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        x = F.relu(self.fc1(x))
+        policy_logits = self.fc_policy(x)
+        value = torch.tanh(self.fc_value(x))  # value in [-1,1]
+        return policy_logits, value.squeeze(-1)
+
+
+# ---------------------------------------------------------------------------
+# Weights helpers
+# ---------------------------------------------------------------------------
+
+def load_dummy_weights(model: nn.Module) -> None:
+    """Initialise ``model`` with deterministic dummy weights.
+
+    The dummy weights produce uniform policy and zero value, allowing the
+    surrounding code to operate before real training data exists.
+    """
+    for p in model.parameters():
+        nn.init.zeros_(p)

--- a/chess_ai/nn/torch_net.py
+++ b/chess_ai/nn/torch_net.py
@@ -1,0 +1,88 @@
+"""PyTorch network wrapper for chess AI.
+
+The :class:`TorchNet` class exposes a ``predict_many`` method compatible with
+:mod:`chess_ai.batched_mcts`. It can load either dummy weights or real weights
+from disk based on a configuration file.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+import chess
+import torch
+import yaml
+
+from .simple_model import (
+    SimpleChessModel,
+    board_to_tensor,
+    load_dummy_weights,
+)
+
+
+class TorchNet:
+    """Wrapper around :class:`SimpleChessModel` providing ``predict_many``."""
+
+    def __init__(self, model: SimpleChessModel | None = None, device: str | None = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = model or SimpleChessModel()
+        self.model.to(self.device)
+        self.model.eval()
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(cls, path: str = "configs/nn.yaml") -> "TorchNet":
+        """Create a :class:`TorchNet` based on a YAML config file."""
+        with open(path, "r", encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh) or {}
+        net = cls()
+        if cfg.get("use_dummy_model", True):
+            load_dummy_weights(net.model)
+        else:
+            weights = cfg.get("weights")
+            if weights:
+                state = torch.load(weights, map_location=net.device)
+                net.model.load_state_dict(state)
+        return net
+
+    # ------------------------------------------------------------------
+    def load_dummy_weights(self) -> None:
+        """Public helper to load dummy weights into the model."""
+        load_dummy_weights(self.model)
+
+    # ------------------------------------------------------------------
+    def predict_many(self, boards: Iterable[chess.Board]) -> List[Tuple[Dict[chess.Move, float], float]]:
+        """Evaluate a batch of boards returning policy and value for each."""
+        boards_list = list(boards)
+        if not boards_list:
+            return []
+        batch = torch.stack([board_to_tensor(b) for b in boards_list]).to(self.device)
+        with torch.no_grad():
+            policy_logits, values = self.model(batch)
+        results: List[Tuple[Dict[chess.Move, float], float]] = []
+        for b, logits, v in zip(boards_list, policy_logits, values):
+            legal = list(b.legal_moves)
+            policy: Dict[chess.Move, float] = {}
+            if legal:
+                idx = torch.tensor([m.from_square * 64 + m.to_square for m in legal], device=logits.device)
+                probs = torch.softmax(logits[idx], dim=0).cpu().tolist()
+                policy = {m: p for m, p in zip(legal, probs)}
+            results.append((policy, float(v.item())))
+        return results
+
+
+# ---------------------------------------------------------------------------
+# CLI helper
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="TorchNet demo")
+    parser.add_argument("--config", default="configs/nn.yaml", help="Path to nn config file")
+    args = parser.parse_args()
+
+    net = TorchNet.from_config(args.config)
+    board = chess.Board()
+    policy, value = net.predict_many([board])[0]
+    print(f"Value: {value:.3f}, policy moves: {len(policy)}")

--- a/configs/nn.yaml
+++ b/configs/nn.yaml
@@ -1,0 +1,5 @@
+# Configuration for neural network usage
+# use_dummy_model: when true, TorchNet will initialise with zero weights
+use_dummy_model: true
+# weights: optional path to a trained model's state_dict
+weights:


### PR DESCRIPTION
## Summary
- add minimal feed-forward `SimpleChessModel` with policy and value heads
- wrap model in `TorchNet` providing `predict_many` and `load_dummy_weights`
- introduce `configs/nn.yaml` to toggle dummy weights or load trained models

## Testing
- `pytest tests/test_random_bot.py -q`
- `pytest tests/test_batched_mcts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5df9fa5dc8325b009372cb9f5d273