### PR TITLE
Refactor attacked square calculation to use coordinates

### DIFF
--- a/metrics/attacked_squares.py
+++ b/metrics/attacked_squares.py
@@ -1,8 +1,8 @@
 import chess
 
 
-def calculate_attacked_squares(piece: chess.Piece, board: chess.Board) -> list[int]:
-    """Calculate squares ``piece`` attacks on ``board``.
+def calculate_attacked_squares(square: int, board: chess.Board) -> list[int]:
+    """Calculate squares attacked from ``square`` on ``board``.
 
     The function is a light wrapper around :meth:`chess.Board.attacks`.
     ``Board.attacks`` returns a :class:`chess.SquareSet`, which is converted
@@ -11,27 +11,24 @@ def calculate_attacked_squares(piece: chess.Piece, board: chess.Board) -> list[i
 
     Parameters
     ----------
-    piece:
-        The :class:`chess.Piece` whose attacks are being calculated.  The
-        function verifies that this piece exists on ``board``.
+    square:
+        The board coordinate whose attacks are being calculated.
     board:
         The current :class:`chess.Board` instance.
 
     Returns
     -------
     list[int]
-        Squares (as integers) that ``piece`` attacks.
+        Squares (as integers) that the piece on ``square`` attacks.
 
     Raises
     ------
     ValueError
-        If ``piece`` is not present on ``board``.
+        If ``square`` does not contain a piece on ``board``.
     """
 
-    piece_squares: chess.SquareSet = board.pieces(piece.piece_type, piece.color)
-    if not piece_squares:
-        raise ValueError(f"{piece} is not on the board")
+    if board.piece_at(square) is None:
+        raise ValueError(f"no piece at square {square}")
 
-    piece_square = piece_squares.pop()
-    attacked_squares: chess.SquareSet = board.attacks(piece_square)
+    attacked_squares: chess.SquareSet = board.attacks(square)
     return list(attacked_squares)

--- a/metrics/test_attacked_squares.py
+++ b/metrics/test_attacked_squares.py
@@ -19,7 +19,7 @@ def test_attacked_squares() -> None:
     piece = chess.Piece(chess.ROOK, chess.WHITE)
     board.set_piece_at(square, piece)
 
-    result = calculate_attacked_squares(piece, board)
+    result = calculate_attacked_squares(square, board)
     expected = list(board.attacks(square))
 
     assert result == expected
@@ -27,11 +27,11 @@ def test_attacked_squares() -> None:
 
 
 def test_calculate_attacked_squares_without_piece() -> None:
-    """``calculate_attacked_squares`` requires the piece to be on the board."""
+    """``calculate_attacked_squares`` requires a piece on the target square."""
     board = chess.Board()
     board.clear()  # Ensure the board has no pieces
-    missing_piece = chess.Piece(chess.BISHOP, chess.WHITE)
+    square = chess.E1
 
     with pytest.raises(ValueError):
-        calculate_attacked_squares(missing_piece, board)
+        calculate_attacked_squares(square, board)
 


### PR DESCRIPTION
## Summary
- simplify attacked squares helper to accept a square index rather than a piece
- adjust tests to use square coordinates and validate empty squares raise `ValueError`

## Testing
- `pytest metrics/test_attacked_squares.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c5560ff48325b66bda57adbfac20