### PR TITLE
Add dynamic king value evaluation

### DIFF
--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -14,6 +14,44 @@ CENTER_SQUARES = [chess.E4, chess.D4, chess.E5, chess.D5]
 # considering capturing moves.  Encourages material recovery when behind.
 MATERIAL_DEFICIT_BONUS = 10
 
+
+def calculate_king_value(board: chess.Board, color: chess.Color | None = None) -> int:
+    """Return a dynamic material value for the king.
+
+    The king's value scales with the material of its own side to roughly
+    reflect how difficult it is to checkmate.  It is computed as::
+
+        8*P + 2*B + 2*N + 2*R + Q
+
+    where ``P`` is the number of allied pawns and so on.  If the opponent has
+    no queen the king is considered slightly safer and its value is reduced by
+    15%.
+
+    Parameters
+    ----------
+    board:
+        Current position to evaluate.
+    color:
+        Side for which to compute the king's value.  Defaults to the side to
+        move.
+    """
+
+    if color is None:
+        color = board.turn
+
+    value = (
+        8 * len(board.pieces(chess.PAWN, color))
+        + 2 * len(board.pieces(chess.BISHOP, color))
+        + 2 * len(board.pieces(chess.KNIGHT, color))
+        + 2 * len(board.pieces(chess.ROOK, color))
+        + len(board.pieces(chess.QUEEN, color))
+    )
+
+    if not board.pieces(chess.QUEEN, not color):
+        value = int(value * 0.85)
+
+    return value
+
 class ChessBot:
     def __init__(self, color: bool):
         self.color = color

--- a/chess_ai/hybrid_bot/evaluation.py
+++ b/chess_ai/hybrid_bot/evaluation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import chess
 
-from ..piece_values import dynamic_piece_value
+from ..chess_bot import calculate_king_value
 
 # Basic piece values in centipawns.  The king's base value is determined
 # dynamically at evaluation time.
@@ -16,28 +16,6 @@ PIECE_VALUES = {
     chess.QUEEN: 900,
     chess.KING: 0,
 }
-
-
-def calculate_king_value(board: chess.Board, color: chess.Color | None = None) -> int:
-    """Return a material based value for the king.
-
-    The king's value is defined as the sum of its allied pieces' dynamic
-    values.  If the opponent has lost major material (e.g. the queen), the
-    king becomes relatively safer and its value increases slightly.
-    """
-
-    if color is None:
-        color = board.turn
-
-    value = 0
-    for _, piece in board.piece_map().items():
-        if piece.color == color and piece.piece_type != chess.KING:
-            value += dynamic_piece_value(piece, board)
-
-    if not board.pieces(chess.QUEEN, not color):
-        value = int(value * 1.1)
-
-    return value
 
 
 def evaluate_position(board: chess.Board) -> float:


### PR DESCRIPTION
## Summary
- introduce `calculate_king_value` to score king based on friendly material and opponent queen presence
- integrate dynamic king value into piece evaluation and hybrid evaluation

## Testing
- `pytest -q` *(fails: cannot import some PySide6 symbols)*
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5eb2069688325aed8a57465579c8a