### PR TITLE
chore: ignore vendored torch binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 # Qt/PySide (збірки)
 *.qrc.dep
 *.qm
+
+# Vendored Torch libraries
+vendors/torch/torch/lib/


### PR DESCRIPTION
## Summary
- ignore Torch library binaries under vendors/torch/torch/lib

## Testing
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a758f1307c8325986e494c0d4c54eb