### PR TITLE
Add KingValueBot and integrate dynamic king evaluation

### DIFF
--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -1,6 +1,7 @@
 """chess_ai package"""
 
 from .hybrid_bot import HybridOrchestrator
-from .bot_agent import HybridBot, KingValueBot
+from .bot_agent import HybridBot
+from .king_value_bot import KingValueBot
 
 __all__ = ["HybridOrchestrator", "HybridBot", "KingValueBot"]

--- a/chess_ai/bot_agent.py
+++ b/chess_ai/bot_agent.py
@@ -95,6 +95,19 @@ except Exception:
             m = random.choice(moves) if moves else None
             return m, "LOW | RandomBot(STUB): random"
 
+try:
+    from .king_value_bot import KingValueBot  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    class KingValueBot(ChessBot):
+        def choose_move(
+            self,
+            board: chess.Board,
+            context: GameContext | None = None,
+            evaluator: Evaluator | None = None,
+            debug: bool = True,
+        ):
+            return super().choose_move(board, context, evaluator, debug)
+
 
 class HybridBot:
     """Bot that blends MCTS and alpha-beta via :class:`HybridOrchestrator`."""
@@ -134,54 +147,6 @@ class HybridBot:
         reason = f"HYBRID | {diag.get('chosen')}" if isinstance(diag, dict) else "HYBRID"
         return move, reason
 
-
-class KingValueBot:
-    """MCTS/alpha-beta bot using dynamic king coefficient evaluation.
-
-    This bot delegates move selection to :class:`HybridOrchestrator` which
-    blends batched Monte Carlo tree search visit counts with alpha-beta scores.
-    The underlying evaluation function employs a dynamic king value, making the
-    king's worth depend on surrounding material.  Users can configure the
-    number of MCTS simulations, the depth of the validating alpha-beta search
-    and the λ-mix parameter controlling how the two scores are combined.
-    """
-
-    def __init__(
-        self,
-        color: bool,
-        ab_depth: int = 3,
-        mcts_simulations: int = 64,
-        top_k: int = 3,
-        lam: float = 0.5,
-    ) -> None:
-        self.color = color
-        if HybridOrchestrator is None:
-            self.impl = None
-        else:
-            self.impl = HybridOrchestrator(
-                color,
-                ab_depth=ab_depth,
-                mcts_simulations=mcts_simulations,
-                top_k=top_k,
-                lam=lam,
-            )
-
-    def choose_move(
-        self,
-        board: chess.Board,
-        context: GameContext | None = None,
-        evaluator: Evaluator | None = None,
-        debug: bool = True,
-    ):
-        if self.impl is None:
-            moves = list(board.legal_moves)
-            m = random.choice(moves) if moves else None
-            return m, "KINGVAL(STUB): random"
-        move, diag = self.impl.choose_move(board)
-        reason = (
-            f"KINGVAL | {diag.get('chosen')}" if isinstance(diag, dict) else "KINGVAL"
-        )
-        return move, reason
 
 # ---------- Cow Opening (окремий планер) ----------
 class CowOpeningPlanner:

--- a/chess_ai/chess_bot.py
+++ b/chess_ai/chess_bot.py
@@ -156,7 +156,16 @@ class ChessBot:
             target_piece = board.piece_at(move.to_square)
             from_piece = board.piece_at(move.from_square)
             if target_piece and from_piece:
-                gain = dynamic_piece_value(target_piece, board) - dynamic_piece_value(from_piece, board)
+                # Evaluate pieces with dynamic king-aware values
+                if target_piece.piece_type == chess.KING:
+                    target_val = calculate_king_value(board, target_piece.color)
+                else:
+                    target_val = dynamic_piece_value(target_piece, board)
+                if from_piece.piece_type == chess.KING:
+                    from_val = calculate_king_value(board, from_piece.color)
+                else:
+                    from_val = dynamic_piece_value(from_piece, board)
+                gain = target_val - from_val
                 score += gain
                 if context and context.material_diff < 0:
                     bonus = abs(context.material_diff) * MATERIAL_DEFICIT_BONUS

--- a/chess_ai/king_value_bot.py
+++ b/chess_ai/king_value_bot.py
@@ -1,0 +1,32 @@
+import chess
+
+from .chess_bot import ChessBot, calculate_king_value
+from utils import GameContext
+from core.evaluator import Evaluator
+
+
+class KingValueBot(ChessBot):
+    """Variant of :class:`ChessBot` that rewards lowering the opponent's king value.
+
+    The bot uses :func:`calculate_king_value` to compute how a move changes the
+    dynamic material value of the enemy king.  Moves that reduce this value –
+    typically by trading off the opponent's material – receive an additional
+    bonus in the evaluation score.
+    """
+
+    def evaluate_move(self, board: chess.Board, move: chess.Move, context: GameContext | None = None):
+        score, reason = super().evaluate_move(board, move, context)
+        opp_color = not self.color
+        before = calculate_king_value(board, opp_color)
+        tmp = board.copy(stack=False)
+        tmp.push(move)
+        after = calculate_king_value(tmp, opp_color)
+        delta = before - after
+        if delta:
+            score += delta
+            bonus_reason = f"king value pressure (+{delta})"
+            reason = f"{reason} | {bonus_reason}" if reason else bonus_reason
+        return score, reason
+
+
+__all__ = ["KingValueBot"]


### PR DESCRIPTION
## Summary
- compute king-aware piece values during captures in `ChessBot`
- implement `KingValueBot` wrapper highlighting dynamic king coefficient
- expose `KingValueBot` via `bot_agent` factory and package exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adfa2caf5083258220f9a27406bf74