### PR TITLE
Add test for vendored package imports

### DIFF
--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the vendored packages directory is available on PYTHONPATH.
+VENDOR_DIR = Path(__file__).resolve().parent.parent / "vendors"
+if str(VENDOR_DIR) not in sys.path:
+    sys.path.insert(0, str(VENDOR_DIR))
+
+MODULES = ["python_chess", "torch", "rpy2", "matplotlib"]
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_vendor_imports(module_name):
+    module = pytest.importorskip(module_name)
+    version = getattr(module, "__version__", "")
+    assert version, f"{module_name} failed to provide a __version__"


### PR DESCRIPTION
## Summary
- add test verifying that vendored package directory is on `PYTHONPATH`
- attempt imports of `python_chess`, `torch`, `rpy2`, and `matplotlib` and check that each exposes a non-empty `__version__`

## Testing
- `pytest tests/test_vendor_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae03ae0b8083258415a5eab76e0afa