### PR TITLE
Remove duplicated board metrics test

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -5,7 +5,6 @@ from core.piece import Pawn, Knight
 from core.board_analyzer import BoardAnalyzer
 from core.evaluation_tuner import EvaluationTuner
 from core.agent_evaluator import AgentEvaluator
-from core.metrics import BoardMetrics
 
 
 def test_agent_evaluator():
@@ -21,19 +20,3 @@ def test_agent_evaluator():
     score = agent.evaluate(board, analyzer)
 
     assert isinstance(score, (int, float)), "Score is not numeric!"
-
-
-def test_board_metrics():
-    board = Board()
-    board.place_piece(Pawn("white", "e2"))
-    board.place_piece(Knight("white", "g1"))
-    board.place_piece(Pawn("black", "e7"))
-
-    analyzer = BoardAnalyzer(board)
-    metrics = BoardMetrics()
-    metrics.update_from_board(board, analyzer)
-
-    result = metrics.get_metrics()
-
-    assert isinstance(result, dict), "Metrics result is not a dict!"
-    assert "material_balance" in result, "No material_balance key found!"


### PR DESCRIPTION
## Summary
- remove redundant BoardMetrics test from evaluator tests

## Testing
- `pytest tests/test_evaluator.py tests/test_metrics.py -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install python-chess -t vendors/` *(fails: Could not find a version that satisfies the requirement python-chess)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98019270832584a43a1cf970cb33