### PR TITLE
Add requirements.txt for dependency installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
 matplotlib
-rpy2
 python-chess
+rpy2
+torch


### PR DESCRIPTION
## Summary
- provide project dependencies in `requirements.txt`

## Testing
- `pip install -r requirements.txt -q` *(fails: Could not find a version that satisfies the requirement matplotlib)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68aee4df00288325a189243bcbc4d7eb