### PR TITLE
Document and list third-party dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,22 @@ pytest
 ```
 
 ## Dependencies
-
-Install required packages with:
+Install core requirements with:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+`requirements.txt` lists both mandatory and optional packages:
+
+- `python-chess`, `torch`, and `PyYAML` are required for the AI engine.
+- `matplotlib` plots profiling metrics.
+- `rpy2` enables optional R-based evaluation and requires an R runtime.
+- `PySide6` provides GUI widgets used in viewer utilities and some tests.
+- `pytest` is needed to run the test suite.
+
+Missing optional libraries may be vendored by placing them under `vendors/`,
+which the test suite automatically adds to `sys.path`.
 
 Run the dependency import test to verify optional libraries are available:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-torch
-matplotlib
-rpy2
-python-chess
+python-chess>=1.9
+PyYAML>=6.0
+torch>=2.0
+matplotlib>=3.7  # optional: plotting utilities
+rpy2>=3.5        # optional: R evaluation bridge
+PySide6>=6.5     # optional: GUI components
+pytest>=7.4      # test suite


### PR DESCRIPTION
## Summary
- enumerate and document runtime and optional dependencies in README
- expand requirements.txt with python-chess, PyYAML, torch, matplotlib, rpy2, PySide6 and pytest

## Testing
- `pytest tests/test_vendor_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aee4ef95c4832580058234ba62c148