### PR TITLE
Highlight selected moves in timeline and show move numbers

### DIFF
--- a/run_viewer.py
+++ b/run_viewer.py
@@ -222,6 +222,7 @@ class RunViewer(QWidget):
     def _on_timeline_click(self, idx: int, is_white: bool) -> None:
         if not self.current_run:
             return
+        self.timeline.set_selected(idx, is_white)
         fen_idx = idx * 2 + (0 if is_white else 1)
         fens = self.current_run.get("fens", [])
         if 0 <= fen_idx < len(fens):


### PR DESCRIPTION
## Summary
- label each column in `UsageTimeline` with its move number
- highlight selected segments in the timeline
- update `RunViewer` to sync selection with the timeline

## Testing
- `pytest` *(fails: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68aef47ec7348325a74eded4b046c2a3