### PR TITLE
Add escape square heuristic and integrate into FortifyBot

### DIFF
--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -7,6 +7,32 @@ def piece_value(piece):
               chess.ROOK: 5, chess.QUEEN: 9, chess.KING: 0}
     return values.get(piece.piece_type, 0)
 
+
+def escape_squares(board: chess.Board, square: int) -> set[chess.Move]:
+    """Return the set of safe moves for the piece on ``square``.
+
+    A move is considered an "escape" if after making it the piece is not
+    attacked by the opponent.  The original ``board.turn`` is restored when
+    finished so the function is side-effect free for callers.
+    """
+
+    piece = board.piece_at(square)
+    if piece is None:
+        return set()
+
+    orig_turn = board.turn
+    board.turn = piece.color
+    escapes: set[chess.Move] = set()
+    for mv in board.legal_moves:
+        if mv.from_square != square:
+            continue
+        board.push(mv)
+        if not board.is_attacked_by(not piece.color, mv.to_square):
+            escapes.add(mv)
+        board.pop()
+    board.turn = orig_turn
+    return escapes
+
 class Evaluator:
     def __init__(
         self,

--- a/tests/test_escape_squares.py
+++ b/tests/test_escape_squares.py
@@ -1,0 +1,23 @@
+import pytest
+
+chess = pytest.importorskip("chess")
+if not hasattr(chess, "Board"):
+    pytest.skip("python-chess not installed", allow_module_level=True)
+
+from core.evaluator import escape_squares
+
+
+def _moves_to_squares(moves):
+    return {m.to_square for m in moves}
+
+
+def test_escape_squares_one_escape():
+    board = chess.Board("n5k1/1B42/8/P7/8/8/8/7K w - - 0 1")
+    escapes = escape_squares(board, chess.A8)
+    assert _moves_to_squares(escapes) == {chess.C7}
+
+
+def test_escape_squares_two_escapes():
+    board = chess.Board("n5k1/1B42/8/8/8/8/8/7K w - - 0 1")
+    escapes = escape_squares(board, chess.A8)
+    assert _moves_to_squares(escapes) == {chess.B6, chess.C7}


### PR DESCRIPTION
## Summary
- add `escape_squares` helper for safe moves
- score moves by reducing opponent escape options in `FortifyBot`
- test escape square detection scenarios

## Testing
- `pytest tests/test_escape_squares.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aef8dffd30832584d78341aa841603