### PR TITLE
Integrate neural network bot into dynamic agent

### DIFF
--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -11,6 +11,7 @@ from .endgame_bot import EndgameBot
 from .fortify_bot import FortifyBot
 from .random_bot import RandomBot
 from .critical_bot import CriticalBot
+from .neural_bot import NeuralBot
 from core.evaluator import Evaluator
 from utils import GameContext
 
@@ -38,6 +39,7 @@ class DynamicBot:
         self.register_agent(EndgameBot(color), weights.get("endgame", 1.0))
         self.register_agent(RandomBot(color), weights.get("random", 1.0))
         self.register_agent(ChessBot(color), weights.get("center", 1.0))
+        self.register_agent(NeuralBot(color), weights.get("neural", 1.0))
 
     def register_agent(self, agent: object, weight: float = 1.0) -> None:
         """Register a sub-agent with an optional weight."""

--- a/chess_ai/neural_bot.py
+++ b/chess_ai/neural_bot.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Neural-network powered sub-bot using :class:`TorchNet`.
+
+The network is loaded lazily to avoid importing the heavy ``torch`` package
+unless the bot is actually queried for a move.  This keeps unit tests lightweight
+and maintains API compatibility with other agents.
+"""
+
+import chess
+
+from core.evaluator import Evaluator
+from utils import GameContext
+
+# Shared network instance reused across bots.  Annotated as a forward reference
+# so that importing this module does not require ``torch``.
+_SHARED_NET: "TorchNet | None" = None
+
+
+class NeuralBot:
+    """Bot that selects moves based on a neural network policy."""
+
+    def __init__(self, color: bool, net: "TorchNet" | None = None) -> None:
+        self.color = color
+        self._net = net
+
+    # ------------------------------------------------------------------
+    def _get_net(self) -> "TorchNet":
+        """Return a network instance, creating one on first use.
+
+        If PyTorch or the network configuration is unavailable, a stub network
+        returning empty policies and zero value is used.  This mirrors the
+        behaviour of other simple agents and keeps tests independent from the
+        ``torch`` dependency.
+        """
+
+        global _SHARED_NET
+        if self._net is not None:
+            return self._net
+        if _SHARED_NET is None:
+            try:  # pragma: no cover - exercised indirectly
+                from .nn import TorchNet
+
+                _SHARED_NET = TorchNet.from_config()
+            except Exception:  # ImportError or config issues
+                class _StubNet:
+                    def predict_many(self, boards):
+                        return [({}, 0.0) for _ in boards]
+
+                _SHARED_NET = _StubNet()
+        self._net = _SHARED_NET
+        return self._net
+
+    # ------------------------------------------------------------------
+    def choose_move(
+        self,
+        board: chess.Board,
+        context: GameContext | None = None,
+        evaluator: Evaluator | None = None,
+        debug: bool = False,
+    ):
+        """Return a move and confidence derived from the network.
+
+        Parameters
+        ----------
+        board: chess.Board
+            Position to analyse.
+        context: GameContext | None, optional
+            Included for API compatibility (unused).
+        evaluator: Evaluator | None, optional
+            Included for API compatibility (unused).
+        debug: bool, optional
+            Unused flag for interface parity.
+        """
+
+        net = self._get_net()
+        policy, value = net.predict_many([board])[0]
+        if not policy:
+            return None, float(value)
+        move = max(policy.items(), key=lambda kv: kv[1])[0]
+        return move, float(value)

--- a/tests/test_neural_bot.py
+++ b/tests/test_neural_bot.py
@@ -1,0 +1,29 @@
+import chess
+
+from chess_ai.neural_bot import NeuralBot
+from chess_ai.dynamic_bot import DynamicBot
+
+
+class FakeNet:
+    def predict_many(self, boards):
+        policy = {
+            chess.Move.from_uci("e2e4"): 0.7,
+            chess.Move.from_uci("d2d4"): 0.3,
+        }
+        return [(policy, 0.5) for _ in boards]
+
+
+def test_neural_bot_converts_network_output(context, evaluator):
+    board = chess.Board()
+    bot = NeuralBot(chess.WHITE, net=FakeNet())
+    move, conf = bot.choose_move(board, context=context, evaluator=evaluator)
+    assert move == chess.Move.from_uci("e2e4")
+    assert conf == 0.5
+
+
+def test_dynamic_bot_registers_neural_bot():
+    bot = DynamicBot(chess.WHITE, weights={"neural": 0.25})
+    assert any(
+        isinstance(agent, NeuralBot) and weight == 0.25
+        for agent, weight in bot.agents
+    )


### PR DESCRIPTION
## Summary
- add `NeuralBot` that wraps `TorchNet.predict_many` and converts policy/value to move & confidence
- register neural bot in `DynamicBot` with configurable weight
- cover neural bot behaviour and registration with tests

## Testing
- `pytest -q` *(fails: module 'chess' has no attribute 'Board')*
- `pip install chess -q -t /tmp/pychess` *(failed: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af0eb4ab488325a7abe61b7ea51eb2