### PR TITLE
Add neural network heatmap visualizer

### DIFF
--- a/chess_ai/nn/__init__.py
+++ b/chess_ai/nn/__init__.py
@@ -1,5 +1,6 @@
 """Neural network utilities for chess_ai."""
 
 from .torch_net import TorchNet
+from .viz_heatmap import plot_policy_heatmap, plot_value_gradient
 
-__all__ = ["TorchNet"]
+__all__ = ["TorchNet", "plot_policy_heatmap", "plot_value_gradient"]

--- a/chess_ai/nn/torch_net.py
+++ b/chess_ai/nn/torch_net.py
@@ -77,12 +77,23 @@ class TorchNet:
 
 if __name__ == "__main__":
     import argparse
+    from .viz_heatmap import plot_policy_heatmap, plot_value_gradient
 
     parser = argparse.ArgumentParser(description="TorchNet demo")
     parser.add_argument("--config", default="configs/nn.yaml", help="Path to nn config file")
+    parser.add_argument(
+        "--policy-heatmap", help="Save policy heatmap for the initial position"
+    )
+    parser.add_argument(
+        "--value-heatmap", help="Save value-gradient heatmap for the initial position"
+    )
     args = parser.parse_args()
 
     net = TorchNet.from_config(args.config)
     board = chess.Board()
     policy, value = net.predict_many([board])[0]
     print(f"Value: {value:.3f}, policy moves: {len(policy)}")
+    if args.policy_heatmap:
+        plot_policy_heatmap(board, policy, save_path=args.policy_heatmap)
+    if args.value_heatmap:
+        plot_value_gradient(net, board, save_path=args.value_heatmap)

--- a/chess_ai/nn/train.py
+++ b/chess_ai/nn/train.py
@@ -72,6 +72,10 @@ def main() -> None:
     parser.add_argument(
         "--output", default="chess_ai/nn/simple_model.pth", help="Where to save model weights"
     )
+    parser.add_argument(
+        "--heatmap",
+        help="Save value-gradient heatmap for the first training sample to this path",
+    )
     args = parser.parse_args()
 
     dataset = FenOutcomeDataset(args.data)
@@ -80,6 +84,13 @@ def main() -> None:
     train(model, loader, epochs=args.epochs, lr=args.lr)
     torch.save(model.state_dict(), args.output)
     print(f"Saved weights to {args.output}")
+    if args.heatmap and dataset.samples:
+        from .torch_net import TorchNet
+        from .viz_heatmap import plot_value_gradient
+
+        board = chess.Board(dataset.samples[0][0])
+        net = TorchNet(model=model)
+        plot_value_gradient(net, board, save_path=args.heatmap)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entrypoint

--- a/chess_ai/nn/viz_heatmap.py
+++ b/chess_ai/nn/viz_heatmap.py
@@ -1,0 +1,90 @@
+"""Visualization helpers for neural-network predictions.
+
+This module provides small utilities for inspecting the output of
+:class:`chess_ai.nn.torch_net.TorchNet`.  Heatmaps can be generated either
+from move probabilities (policy) or by computing the gradient of the value
+head with respect to the board input.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import chess
+import matplotlib.pyplot as plt
+import torch
+
+from .simple_model import board_to_tensor
+from .torch_net import TorchNet
+
+
+def _setup_axes(ax: plt.Axes) -> None:
+    """Label axes with chess board coordinates."""
+    ax.set_xticks(range(8))
+    ax.set_yticks(range(8))
+    ax.set_xticklabels(list("abcdefgh"))
+    ax.set_yticklabels(list(range(8, 0, -1)))
+    ax.invert_yaxis()
+
+
+def plot_policy_heatmap(
+    board: chess.Board,
+    policy: Dict[chess.Move, float],
+    save_path: str | None = None,
+    show: bool = False,
+) -> None:
+    """Plot an 8×8 heatmap of ``policy`` probabilities.
+
+    The probability mass for each move is accumulated on the destination
+    square.  The resulting heatmap gives a quick overview of which regions the
+    network prefers to move to.
+    """
+
+    grid = torch.zeros(8, 8, dtype=torch.float32)
+    for move, prob in policy.items():
+        r = chess.square_rank(move.to_square)
+        c = chess.square_file(move.to_square)
+        grid[7 - r, c] += prob
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(grid, cmap="magma", vmin=0.0)
+    _setup_axes(ax)
+    fig.colorbar(im, ax=ax)
+
+    if save_path:
+        fig.savefig(save_path, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)
+
+
+def plot_value_gradient(
+    net: TorchNet,
+    board: chess.Board,
+    save_path: str | None = None,
+    show: bool = False,
+) -> None:
+    """Plot a saliency map based on the value head gradient.
+
+    The absolute gradient of the scalar value output with respect to the board
+    representation is summed over piece planes to yield an 8×8 map indicating
+    which squares most influence the evaluation.
+    """
+
+    net.model.zero_grad()
+    inp = board_to_tensor(board).to(net.device).unsqueeze(0)
+    inp.requires_grad_(True)
+    _policy, value = net.model(inp)
+    value.backward()
+    grad = inp.grad[0][: 64 * 12].abs().view(12, 8, 8).sum(0)
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(grad.cpu(), cmap="coolwarm")
+    _setup_axes(ax)
+    fig.colorbar(im, ax=ax)
+
+    if save_path:
+        fig.savefig(save_path, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- add `viz_heatmap` utility for plotting policy and value-gradient maps
- expose optional hooks in `torch_net.py` and training CLI to save heatmaps
- export visualization helpers from `chess_ai.nn`

## Testing
- `pytest -q` *(fails: module 'chess' has no attribute 'Board')*
- `pip install python-chess` *(fails: Could not find a version that satisfies the requirement python-chess)*

------
https://chatgpt.com/codex/tasks/task_e_68af1032600483258c338b70f2af06ed