### PR TITLE
Add optional R evaluator to DynamicBot

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -33,6 +33,12 @@ The overall penalty can be scaled via an optional ``enemy_material`` argument, a
 mapping with ``"white"`` and ``"black"`` keys that reduces the impact of king
 attacks when the opponent has lost major pieces such as the queen.
 
+Set the environment variable ``CHESS_USE_R=1`` or pass ``use_r=True`` to
+``chess_ai.dynamic_bot.DynamicBot`` to activate the R evaluator.  When enabled,
+``DynamicBot`` registers an additional agent that scores moves via the R bridge
+and contributes its colour-adjusted numeric score alongside the existing
+sub‑bots.
+
 ## Pawn structure helpers
 
 - `is_isolated(board, square, files)` – checks whether a pawn has friendly pawns on adjacent files. An isolated pawn triggers `isolated_penalty` in [`pawn_structure_score`](../core/evaluator.py).

--- a/tests/test_dynamic_bot_r.py
+++ b/tests/test_dynamic_bot_r.py
@@ -1,0 +1,40 @@
+"""Tests for optional R integration in :mod:`chess_ai.dynamic_bot`."""
+
+import importlib
+
+import pytest
+
+chess = pytest.importorskip("chess")
+
+
+def test_dynamic_bot_uses_r_agent(monkeypatch):
+    """DynamicBot should consider the R evaluator when enabled."""
+
+    monkeypatch.setenv("CHESS_USE_R", "1")
+    import chess_ai.dynamic_bot as db
+    importlib.reload(db)
+
+    def fake_eval(board: chess.Board) -> float:
+        last = board.peek().uci()
+        return 5.0 if last == "e2e4" else 0.0
+
+    monkeypatch.setattr(db, "_r_eval_board", fake_eval)
+
+    weights = {
+        "aggressive": 0.0,
+        "fortify": 0.0,
+        "critical": 0.0,
+        "endgame": 0.0,
+        "random": 0.0,
+        "center": 0.0,
+        "neural": 0.0,
+        "r": 1.0,
+    }
+
+    bot = db.DynamicBot(chess.WHITE, weights=weights, use_r=True)
+    board = chess.Board()
+    move, score = bot.choose_move(board)
+
+    assert move == chess.Move.from_uci("e2e4")
+    assert score == 5.0
+


### PR DESCRIPTION
## Summary
- integrate optional R-based evaluation into DynamicBot
- allow enabling via `CHESS_USE_R` env var or `use_r` flag
- document R setup and activation steps

## Testing
- `pytest tests/test_dynamic_bot_r.py tests/test_r_bridge.py -q` *(skipped: python-chess not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af2013e0fc8325b3bc7f411efd9959