### PR TITLE
Add tests for load_runs path handling

### DIFF
--- a/tests/test_load_runs.py
+++ b/tests/test_load_runs.py
@@ -1,6 +1,9 @@
 import json
 import os
 import tempfile
+
+import pytest
+
 from utils.load_runs import load_runs
 
 
@@ -17,8 +20,10 @@ def test_load_runs_valid():
             json.dump(sample, f)
 
         runs = load_runs(tmpdir)
+        assert isinstance(runs, list)
         assert len(runs) == 1
         run = runs[0]
+        assert isinstance(run, dict)
         assert run["game_id"] == "game1"
         assert run["moves"] == sample["moves"]
         assert run["fens"] == sample["fens"]
@@ -58,6 +63,13 @@ def test_load_runs_missing_result_defaults_star():
         runs = load_runs(tmpdir)
         assert len(runs) == 1
         assert runs[0]["result"] == "*"
+
+
+def test_load_runs_missing_directory():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        missing = os.path.join(tmpdir, "missing")
+        with pytest.raises(FileNotFoundError):
+            load_runs(missing)
 
 
 if __name__ == "__main__":

--- a/utils/load_runs.py
+++ b/utils/load_runs.py
@@ -29,9 +29,14 @@ def load_runs(path: str) -> List[Dict[str, Any]]:
     ------
     ValueError
         If a JSON file is missing any required keys.
+    FileNotFoundError
+        If *path* does not exist.
     """
     runs: List[Dict[str, Any]] = []
     base_path = Path(path)
+
+    if not base_path.exists():
+        raise FileNotFoundError(f"Directory not found: {path}")
 
     for file in sorted(base_path.glob("*.json")):
         with file.open("r", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- ensure `load_runs` raises `FileNotFoundError` for missing directories
- test `load_runs` return type and missing path errors

## Testing
- `pytest tests/test_load_runs.py -q` *(fails: python-chess not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af220de36c8325b74f6d37c2881328