### PR TITLE
Improve python-chess stub handling

### DIFF
--- a/tests/test_chess_stub.py
+++ b/tests/test_chess_stub.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_stub_raises_importerror_outside_pytest():
+    code = (
+        "import sys\n"
+        "sys.path.append('vendors')\n"
+        "import chess\n"
+        "try:\n"
+        "    chess.A1\n"
+        "except ImportError:\n"
+        "    sys.exit(0)\n"
+        "else:\n"
+        "    sys.exit(1)\n"
+    )
+    root = Path(__file__).resolve().parent.parent
+    result = subprocess.run([sys.executable, "-c", code], cwd=root)
+    assert result.returncode == 0

--- a/vendors/chess/__init__.py
+++ b/vendors/chess/__init__.py
@@ -15,15 +15,27 @@ missing dependency.
 
 from __future__ import annotations
 
+import os
+import inspect
+
 try:  # pragma: no cover - pytest may not be installed outside tests
     import pytest  # type: ignore
 except Exception:  # pragma: no cover - outside of pytest
     pytest = None  # type: ignore
 
 
+def _running_under_pytest() -> bool:
+    """Return ``True`` when code is executed within a pytest run."""
+    if pytest is None:  # pragma: no cover - outside of pytest
+        return False
+    # Inspect the call stack for frames originating from ``_pytest`` modules,
+    # which indicates that pytest is orchestrating execution.
+    return any(frame.filename and "_pytest" in frame.filename for frame in inspect.stack())
+
+
 def __getattr__(name: str):  # pragma: no cover - executed only when missing dep
     """On attribute access, skip dependent tests or raise ``ImportError``."""
-    if pytest is not None:
+    if _running_under_pytest():
         pytest.skip("python-chess not installed", allow_module_level=True)
     raise ImportError("python-chess is required for this feature")
 


### PR DESCRIPTION
## Summary
- avoid skipping scripts when optional python-chess library is missing by detecting pytest via call stack
- add regression test verifying stub raises ImportError outside of pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af286ac06c8325af0ef31f54a772bd