### PR TITLE
Add gradient overlays and last-move highlighting

### DIFF
--- a/docs/ui_overlays.md
+++ b/docs/ui_overlays.md
@@ -1,0 +1,47 @@
+# UI Overlays
+
+The viewer can render additional overlays on top of board cells using
+`DrawerManager`.  It now understands two sources of analysis data:
+
+* **Heatmaps** – JSON files in `analysis/heatmaps/` containing 8×8
+  matrices of numbers in the range 0–1.  Each value is rendered as a
+  translucent square with a colour gradient from green (`0.0`) to red
+  (`1.0`).
+* **Agent metrics** – key/value pairs stored in
+  `analysis/agent_metrics.json`.  The file is loaded on start and the
+  data is available through `DrawerManager.agent_metrics` for debugging
+  or displaying aggregate numbers.
+
+## Heatmap format
+
+Example `analysis/heatmaps/example.json`:
+
+```json
+[
+  [0.0, 0.2, 0.1, 0.0, 0.0, 0.1, 0.2, 0.0],
+  [0.0, 0.3, 0.4, 0.0, 0.0, 0.4, 0.3, 0.0],
+  [0.1, 0.4, 0.6, 0.0, 0.0, 0.6, 0.4, 0.1],
+  [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+  [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+  [0.1, 0.4, 0.6, 0.0, 0.0, 0.6, 0.4, 0.1],
+  [0.0, 0.3, 0.4, 0.0, 0.0, 0.4, 0.3, 0.0],
+  [0.0, 0.2, 0.1, 0.0, 0.0, 0.1, 0.2, 0.0]
+]
+```
+
+## Usage
+
+```python
+import chess
+from ui.drawer_manager import DrawerManager
+
+board = chess.Board()
+drawer = DrawerManager()
+
+drawer.collect_overlays({}, board)
+# Access gradient overlays via drawer.overlays
+metrics = drawer.agent_metrics
+```
+
+The `MiniBoard` automatically highlights the last move by colouring the
+origin and destination squares as well as the piece symbols.

--- a/ui/cell.py
+++ b/ui/cell.py
@@ -28,6 +28,7 @@ class Cell(QLabel):
     def set_highlight(self, active):
         palette = self.palette()
         palette.setColor(QPalette.Window, QColor("#ffcc00") if active else self.base_color)
+        palette.setColor(QPalette.WindowText, QColor("red") if active else QColor("black"))
         self.setPalette(palette)
 
     def set_attack_count(self, count):
@@ -89,3 +90,9 @@ class Cell(QLabel):
                 painter.setBrush(QColor("yellow"))
                 painter.setPen(Qt.NoPen)
                 painter.drawEllipse(int(42 * self.scale), int(4 * self.scale), int(10 * self.scale), int(10 * self.scale))
+            elif overlay_type == "gradient":
+                painter.setBrush(QColor(color))
+                painter.setPen(Qt.NoPen)
+                painter.setOpacity(0.4)
+                painter.drawRect(0, 0, self.width(), self.height())
+                painter.setOpacity(1.0)

--- a/ui/mini_board.py
+++ b/ui/mini_board.py
@@ -66,6 +66,15 @@ class MiniBoard(QWidget):
                 piece_objects[square] = piece_class_factory(piece, pos)
 
         self.drawer_manager.collect_overlays(piece_objects, self.board)
+        last_move = self.board.move_stack[-1] if self.board.move_stack else None
+        highlights = set()
+        if last_move:
+            fr = 7 - chess.square_rank(last_move.from_square)
+            fc = chess.square_file(last_move.from_square)
+            tr = 7 - chess.square_rank(last_move.to_square)
+            tc = chess.square_file(last_move.to_square)
+            highlights.add((fr, fc))
+            highlights.add((tr, tc))
 
         for row in range(8):
             for col in range(8):
@@ -75,6 +84,6 @@ class MiniBoard(QWidget):
                 cell.set_piece(piece.symbol() if piece else None)
                 attackers = self.board.attackers(not self.board.turn, square)
                 cell.set_attack_count(len(attackers))
-                cell.set_highlight(False)
+                cell.set_highlight((row, col) in highlights)
                 cell.update()
 


### PR DESCRIPTION
## Summary
- load analysis heatmaps and agent metrics in DrawerManager
- support gradient overlays and auto-highlight last move squares/pieces
- document heatmap format and overlay usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af66364ed883258156044abff89c4c