### PR TITLE
Add Docker and Codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Chess Codespace",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"]
+    }
+  },
+  "postCreateCommand": "pip install -r requirements.txt && pip install pytest"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/python:3.10
+
+# Avoid prompts from apt operations
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python dependencies
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
+    && pip install --no-cache-dir pytest \
+    && rm -rf /tmp/pip-tmp
+
+# Set the default workdir
+WORKDIR /workspace
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- add Dockerfile to build testing environment with Python dependencies
- configure Codespaces via devcontainer to use Docker image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6218c11c832588f6a8c555121669