### PR TITLE
Make RandomBot optional in DynamicBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ values when creating `DynamicBot`:
 from chess_ai.dynamic_bot import DynamicBot
 import chess
 
-bot = DynamicBot(chess.WHITE, weights={"aggressive": 1.5, "fortify": 0.5})
+# RandomBot is disabled by default; pass a positive weight to enable it.
+bot = DynamicBot(
+    chess.WHITE, weights={"aggressive": 1.5, "fortify": 0.5, "random": 0.5}
+)
 ```
+
+By default all deterministic sub-bots have a weight of `1.0` while
+`RandomBot` is assigned a weight of `0.0` and therefore excluded unless a
+positive weight is supplied.
 
 ### Example usage
 

--- a/chess_ai/dynamic_bot.py
+++ b/chess_ai/dynamic_bot.py
@@ -91,12 +91,18 @@ class DynamicBot:
         # Deeper search engine used to break ties or provide a fallback.
         self.decision_engine = DecisionEngine()
 
-        # Register default agents with provided weights (fallback → 1.0)
+        # Register default agents with provided weights (fallback → 1.0).
+        # RandomBot is disabled by default and must be explicitly enabled via
+        # ``weights={'random': <value>}`` to avoid unnecessary randomness.
         self.register_agent(AggressiveBot(color), weights.get("aggressive", 1.0))
         self.register_agent(FortifyBot(color), weights.get("fortify", 1.0))
         self.register_agent(CriticalBot(color), weights.get("critical", 1.0))
         self.register_agent(EndgameBot(color), weights.get("endgame", 1.0))
-        self.register_agent(RandomBot(color), weights.get("random", 1.0))
+
+        rand_weight = weights.get("random", 0.0)
+        if rand_weight > 0.0:
+            self.register_agent(RandomBot(color), rand_weight)
+
         self.register_agent(ChessBot(color), weights.get("center", 1.0))
         self.register_agent(NeuralBot(color), weights.get("neural", 1.0))
         if use_r and _r_eval_board is not None:


### PR DESCRIPTION
## Summary
- Disable RandomBot in DynamicBot by default and only register when given a positive weight.
- Document optional RandomBot weighting in README.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af7adb1e2c83259f62f2f62b0a8cf8