### PR TITLE
refactor piece class factory using mapping

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -5,6 +5,17 @@ from dataclasses import dataclass
 from core.piece import Piece, Pawn, Rook, Knight, Bishop, Queen, King
 
 
+# Mapping of python-chess piece symbols to project piece classes
+PIECE_CLASS_MAP = {
+    'p': Pawn,
+    'r': Rook,
+    'n': Knight,
+    'b': Bishop,
+    'q': Queen,
+    'k': King,
+}
+
+
 @dataclass
 class GameContext:
     """Shared positional metrics available to all agents."""
@@ -15,19 +26,8 @@ class GameContext:
 
 def piece_class_factory(piece, pos):
     t = piece.symbol().lower()
-    if t == 'p':
-        return Pawn(piece.color, pos)
-    elif t == 'r':
-        return Rook(piece.color, pos)
-    elif t == 'n':
-        return Knight(piece.color, pos)
-    elif t == 'b':
-        return Bishop(piece.color, pos)
-    elif t == 'q':
-        return Queen(piece.color, pos)
-    elif t == 'k':
-        return King(piece.color, pos)
-    return Piece(piece.color, pos)
+    cls = PIECE_CLASS_MAP.get(t, Piece)
+    return cls(piece.color, pos)
 
 def type_piece_name(piece):
     t = piece.symbol().lower()


### PR DESCRIPTION
## Summary
- map chess piece symbols to their classes
- simplify `piece_class_factory` via mapping with default to `Piece`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af82ccd6dc8325916c99f3c661b16e