### PR TITLE
Add FEN heatmap export

### DIFF
--- a/docs/ui_overlays.md
+++ b/docs/ui_overlays.md
@@ -45,3 +45,26 @@ metrics = drawer.agent_metrics
 
 The `MiniBoard` automatically highlights the last move by colouring the
 origin and destination squares as well as the piece symbols.
+
+## Generating heatmaps from FEN strings
+
+The loader can convert a collection of FEN positions into the move table
+expected by the existing R heatmap script:
+
+```python
+from analysis.loader import export_fen_table
+
+fens = [
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+]
+export_fen_table(fens, csv_path="analysis/heatmaps/fens.csv")
+```
+
+Generate heatmaps by passing the resulting CSV to the R script:
+
+```bash
+Rscript analysis/heatmaps/generate_heatmaps.R analysis/heatmaps/fens.csv
+```
+
+The heatmaps are written back into `analysis/heatmaps/` and can then be
+displayed by the viewer.

--- a/tests/test_export_fen_table.py
+++ b/tests/test_export_fen_table.py
@@ -1,0 +1,20 @@
+import csv
+
+from analysis.loader import export_fen_table
+
+
+def test_export_fen_table(tmp_path):
+    fens = [
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    ]
+    csv_file = tmp_path / "fens.csv"
+    records = export_fen_table(fens, csv_path=str(csv_file))
+
+    # 32 pieces in the starting position plus header line in CSV
+    assert csv_file.exists()
+    with open(csv_file, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 32
+
+    # Ensure at least one known piece/square entry exists
+    assert any(r["piece"] == "king" and r["to"] == "e1" for r in records)


### PR DESCRIPTION
## Summary
- add `export_fen_table` for converting FEN strings into piece/square records
- document FEN-based heatmap generation
- cover FEN export with unit test

## Testing
- `pytest tests/test_export_fen_table.py -q` *(fails: python-chess not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af87086a9c8325a3888219741cec86