### PR TITLE
Add streaming loader with sampling and stats

### DIFF
--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -1,0 +1,31 @@
+# Sampling Run Data
+
+Large collections of recorded games can consume significant memory when loaded
+all at once.  The analysis tools therefore support sampling subsets of games
+for offline processing.
+
+## Random subset
+
+To analyse a random subset of games, specify a sample size and random seed.
+The seed makes the selection reproducible:
+
+```bash
+python -m analysis.loader runs/ --stats --sample-size 1000 --seed 42
+```
+
+This command processes up to **1000** randomly chosen games and prints
+aggregated statistics.  If fewer games are available all of them are used.
+Choose a sample size of at least 1000 games to obtain stable estimates.
+
+## Sliding window
+
+Omit the seed to read the first ``N`` games in sorted order, effectively
+creating a sliding window over the dataset:
+
+```bash
+python -m analysis.loader runs/ --stats --sample-size 1000
+```
+
+This strategy is useful when the games are already shuffled externally.  As
+with random sampling, ensure the window covers **≥1000** games for meaningful
+results.

--- a/tests/test_analysis_loader.py
+++ b/tests/test_analysis_loader.py
@@ -1,0 +1,27 @@
+import json
+from analysis.loader import aggregate_stats
+
+
+def _write_run(path, name, moves, modules_w, modules_b):
+    data = {
+        "moves": moves,
+        "fens": [" "] * len(moves),
+        "modules_w": modules_w,
+        "modules_b": modules_b,
+    }
+    (path / f"{name}.json").write_text(json.dumps(data))
+
+
+def test_aggregate_stats_sampling(tmp_path):
+    _write_run(tmp_path, "g1", ["e2e4"], ["A"], [])
+    _write_run(tmp_path, "g2", ["e2e4", "e7e5"], ["B"], ["C"])
+    _write_run(tmp_path, "g3", ["d2d4"], ["A"], ["B"])
+
+    stats = aggregate_stats(tmp_path, limit=2)
+    assert stats["games"] == 2
+    assert stats["moves"] == 3
+    assert stats["module_usage"] == {"A": 1, "B": 1, "C": 1}
+
+    stats1 = aggregate_stats(tmp_path, limit=2, seed=0)
+    stats2 = aggregate_stats(tmp_path, limit=2, seed=0)
+    assert stats1 == stats2


### PR DESCRIPTION
## Summary
- Stream run files sequentially and compute statistics without loading everything into memory
- Add CLI options for sampling limit and reproducible seeding
- Document sampling strategies for analysing at least 1000 games

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af883247708325b9f2bebee81bd2b0