### PR TITLE
Add R FEN position extraction and Python wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,23 @@ Rscript analysis/heatmaps/generate_heatmaps.R analysis/heatmaps/moves.csv
 
 Heatmap matrices are written as CSV and JSON files into `analysis/heatmaps/`.
 
+## Piece positions from FEN
+
+Generate per-piece coordinates directly from a list of FEN strings using R:
+
+```bash
+Rscript analysis/extract_positions.R fens.txt analysis/positions.csv
+```
+
+From Python the same functionality is available via a small wrapper:
+
+```python
+from analysis.extract_positions import extract_positions
+
+fens = ["rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
+extract_positions(fens, "positions.csv")
+```
+
+The resulting CSV contains `file`, `rank`, and `piece` columns for each board
+entry.
+

--- a/analysis/extract_positions.R
+++ b/analysis/extract_positions.R
@@ -1,0 +1,43 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(readr)
+})
+
+#' Extract piece coordinates from FEN strings
+#'
+#' @param fens Character vector of FEN strings.
+#' @return Data frame with columns `file`, `rank`, and `piece`.
+extract_positions <- function(fens) {
+  records <- data.frame(file = character(), rank = integer(), piece = character(), stringsAsFactors = FALSE)
+  for (fen in fens) {
+    parts <- strsplit(fen, " ")[[1]]
+    board <- parts[1]
+    ranks <- strsplit(board, "/")[[1]]
+    for (r_idx in seq_along(ranks)) {
+      rank_num <- 9 - r_idx
+      row <- ranks[r_idx]
+      file_idx <- 1
+      chars <- strsplit(row, "")[[1]]
+      for (ch in chars) {
+        if (grepl("^[1-8]$", ch)) {
+          file_idx <- file_idx + as.integer(ch)
+        } else {
+          file_letter <- letters[file_idx]
+          records <- rbind(records, data.frame(file = file_letter, rank = rank_num, piece = ch, stringsAsFactors = FALSE))
+          file_idx <- file_idx + 1
+        }
+      }
+    }
+  }
+  records
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+  stop("Usage: extract_positions.R <fen_file> <out_csv>")
+}
+
+fen_strings <- read_lines(args[1])
+positions <- extract_positions(fen_strings)
+write_csv(positions, args[2])

--- a/analysis/extract_positions.py
+++ b/analysis/extract_positions.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+def extract_positions(fens: Iterable[str], csv_path: str) -> None:
+    """Call the R script to extract piece coordinates from *fens*.
+
+    Parameters
+    ----------
+    fens:
+        Iterable of FEN strings.
+    csv_path:
+        Output CSV path that will contain columns ``file``, ``rank`` and ``piece``.
+    """
+
+    script = Path(__file__).with_name("extract_positions.R")
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as tmp:
+        for fen in fens:
+            tmp.write(f"{fen}\n")
+        tmp_path = tmp.name
+
+    subprocess.run(["Rscript", str(script), tmp_path, csv_path], check=True)


### PR DESCRIPTION
## Summary
- add `analysis/extract_positions.R` to convert FEN strings into piece coordinates and write CSV
- provide Python helper `analysis/extract_positions.py` to invoke the R script from Python
- document FEN position extraction usage in the README

## Testing
- `pytest`
- `Rscript analysis/extract_positions.R ...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8b4447988325a670df44601ad0ff