### PR TITLE
Add pattern responder template and loader

### DIFF
--- a/configs/patterns.json
+++ b/configs/patterns.json
@@ -1,0 +1,12 @@
+{
+  "patterns": [
+    {
+      "situation": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR",
+      "action": "e7e5"
+    },
+    {
+      "situation": "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR",
+      "action": "g1f3"
+    }
+  ]
+}

--- a/core/pattern_loader.py
+++ b/core/pattern_loader.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+import chess
+
+
+class PatternResponder:
+    """Loads pattern templates and finds matching actions.
+
+    A pattern is a mapping with two keys:
+    ``situation`` – the piece placement portion of a FEN string,
+    and ``action`` – an arbitrary response (usually a move in UCI format).
+    """
+
+    def __init__(self, patterns: List[Dict[str, Any]]) -> None:
+        self.patterns = patterns
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "PatternResponder":
+        """Create a responder from a JSON or YAML file."""
+        p = Path(path)
+        with p.open("r", encoding="utf8") as fh:
+            if p.suffix in {".yaml", ".yml"}:
+                if yaml is None:  # pragma: no cover - defensive
+                    raise RuntimeError("PyYAML is required for YAML pattern files")
+                data = yaml.safe_load(fh)
+            else:
+                data = json.load(fh)
+        if isinstance(data, dict):
+            patterns = data.get("patterns", [])
+        else:
+            patterns = data
+        return cls(patterns)
+
+    def match(self, board: chess.Board) -> Optional[str]:
+        """Return the action for the current board state, if any."""
+        layout = board.board_fen()
+        for p in self.patterns:
+            if p.get("situation") == layout:
+                return p.get("action")
+        return None

--- a/docs/pattern_templates.md
+++ b/docs/pattern_templates.md
@@ -1,0 +1,27 @@
+# Pattern Templates
+
+The engine can react to predefined board situations using templates
+stored in `configs/patterns.json`.  Each entry describes a specific
+`situation` and an `action` to take when that layout appears on the
+board.
+
+```json
+{
+  "situation": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR",
+  "action": "e7e5"
+}
+```
+
+* `situation` – the piece placement part of a FEN string.
+* `action` – free‑form text, typically a move in UCI notation.
+
+## Extending templates
+
+1. Open `configs/patterns.json`.
+2. Append a new object to the `patterns` list describing the layout
+   you want to detect and the desired action.
+3. Save the file – `PatternResponder` will automatically load the new
+   scenario on the next run.
+
+Use `chess.Board().board_fen()` to retrieve the current board layout
+when crafting new situations.

--- a/tests/test_pattern_loader.py
+++ b/tests/test_pattern_loader.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import chess
+
+from core.pattern_loader import PatternResponder
+
+
+def test_pattern_match() -> None:
+    responder = PatternResponder.from_file(Path("configs/patterns.json"))
+    board = chess.Board()
+    board.push_san("e4")
+    assert responder.match(board) == "e7e5"
+    board.push_san("e5")
+    assert responder.match(board) == "g1f3"


### PR DESCRIPTION
## Summary
- add JSON templates for board situations and responses
- load templates and match board state via `PatternResponder`
- document extending pattern templates and test matcher

## Testing
- `pytest tests/test_pattern_loader.py -vv -rs`
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8c0c78f48325b4ef3a959ab7bfa4