### PR TITLE
Add browser FEN board and exportable overlays

### DIFF
--- a/docs/ui_overlays.md
+++ b/docs/ui_overlays.md
@@ -87,3 +87,43 @@ Rscript analysis/heatmaps/generate_heatmaps.R \
 * `--resolution` – output image resolution in DPI (default `300`).
 
 Run the script with `--help` to see all available options and defaults.
+
+## Browser component
+
+The repository ships with a lightweight JavaScript helper located at
+`ui/fen_board.js`.  It renders a FEN position and applies the overlays and
+agent metrics exported by `DrawerManager`.
+
+### Exporting data
+
+```python
+import json
+import chess
+from ui.drawer_manager import DrawerManager
+
+board = chess.Board()
+drawer = DrawerManager()
+drawer.collect_overlays({}, board)
+data = drawer.export_ui_data()
+data["fen"] = board.fen()
+with open("output/ui_state.json", "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+```
+
+### Rendering in HTML
+
+```html
+<div id="board"></div>
+<div id="metrics"></div>
+<script type="module">
+import {renderFenBoard, renderAgentMetrics} from './ui/fen_board.js';
+
+fetch('output/ui_state.json').then(r => r.json()).then(data => {
+  renderFenBoard('board', data.fen, data.overlays);
+  renderAgentMetrics('metrics', data.agent_metrics);
+});
+</script>
+```
+
+The board is drawn using Unicode characters and each overlay entry is
+applied as a semi-transparent background colour to the respective cell.

--- a/ui/drawer_manager.py
+++ b/ui/drawer_manager.py
@@ -114,3 +114,22 @@ class DrawerManager:
     # ------------------------------------------------------------------
     def get_cell_overlays(self, row, col):
         return self.overlays.get((row, col), [])
+
+    # ------------------------------------------------------------------
+    def export_ui_data(self):
+        """Return overlays, heatmaps and metrics for front-end consumers.
+
+        The overlays are returned as an 8×8 matrix where each entry is a list
+        of ``(type, colour)`` tuples.  Heatmap values are also included so a
+        web client can reconstruct the gradient if desired.  Agent metrics are
+        relayed verbatim from :mod:`analysis.agent_metrics.json`.
+        """
+
+        grid = [[[] for _ in range(8)] for _ in range(8)]
+        for (r, c), items in self.overlays.items():
+            grid[r][c] = items
+        return {
+            "overlays": grid,
+            "heatmaps": self.heatmaps,
+            "agent_metrics": self.agent_metrics,
+        }

--- a/ui/fen_board.js
+++ b/ui/fen_board.js
@@ -1,0 +1,81 @@
+// Utility to render a chess board from a FEN string with overlay support.
+// The module exports a single function `renderFenBoard` that accepts a
+// DOM element (or its id), a FEN string and an optional 8x8 overlay grid.
+// Each overlay entry is a list of `{type, color}` objects.  The colour is
+// applied as a semi-transparent background to the cell.
+
+const PIECE_UNICODE = {
+  'p': '♟', 'r': '♜', 'n': '♞', 'b': '♝', 'q': '♛', 'k': '♚',
+  'P': '♙', 'R': '♖', 'N': '♘', 'B': '♗', 'Q': '♕', 'K': '♔'
+};
+
+function parseFEN(fen) {
+  const [placement] = fen.split(' ');
+  const rows = placement.split('/');
+  const board = [];
+  for (const row of rows) {
+    const cells = [];
+    for (const ch of row) {
+      if (/\d/.test(ch)) {
+        const empties = parseInt(ch, 10);
+        for (let i = 0; i < empties; i++) cells.push(null);
+      } else {
+        cells.push(ch);
+      }
+    }
+    board.push(cells);
+  }
+  return board;
+}
+
+export function renderFenBoard(target, fen, overlays = []) {
+  const el = typeof target === 'string' ? document.getElementById(target) : target;
+  if (!el) return;
+  const board = parseFEN(fen);
+  el.innerHTML = '';
+  el.style.display = 'grid';
+  el.style.gridTemplateColumns = 'repeat(8, 60px)';
+  el.style.gridTemplateRows = 'repeat(8, 60px)';
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const cell = document.createElement('div');
+      cell.className = 'cell ' + ((r + c) % 2 === 0 ? 'white' : 'black');
+      cell.style.width = '60px';
+      cell.style.height = '60px';
+      cell.style.display = 'flex';
+      cell.style.alignItems = 'center';
+      cell.style.justifyContent = 'center';
+      cell.style.fontSize = '36px';
+      const piece = board[r][c];
+      if (piece) cell.textContent = PIECE_UNICODE[piece] || '';
+      const overlay = overlays[r] && overlays[r][c];
+      if (overlay) {
+        // Apply the colour of the last overlay entry.
+        const last = overlay[overlay.length - 1];
+        cell.style.backgroundColor = last.color;
+        cell.style.opacity = '0.7';
+      }
+      el.appendChild(cell);
+    }
+  }
+}
+
+export function renderAgentMetrics(target, metrics) {
+  const el = typeof target === 'string' ? document.getElementById(target) : target;
+  if (!el || !metrics) return;
+  el.innerHTML = '';
+  for (const side of ['white', 'black']) {
+    const box = document.createElement('div');
+    box.innerHTML = `<h3>${side}</h3>`;
+    const data = metrics[side] || {};
+    for (const [key, value] of Object.entries(data)) {
+      box.innerHTML += `<div>${key}: ${value}</div>`;
+    }
+    el.appendChild(box);
+  }
+}
+
+export default {
+  renderFenBoard,
+  renderAgentMetrics
+};


### PR DESCRIPTION
## Summary
- provide `ui/fen_board.js` for rendering boards and metrics in the browser
- expose overlay, heatmap, and metric data via `DrawerManager.export_ui_data`
- document how to export UI data and display it in the new component

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8f3356d883259d0ffd0f497d654f