### PR TITLE
Add integration utilities and documentation

### DIFF
--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -1,0 +1,58 @@
+# Integration Guide
+
+This guide explains how external projects can interact with the chess
+analysis tools of this repository.  The utilities expose functions for
+FEN parsing, heatmap generation and metric calculation.
+
+## API functions
+
+```python
+from utils.integration import parse_fen, generate_heatmaps, compute_metrics
+```
+
+* `parse_fen(fen)` – return an 8×8 board state representation.
+* `generate_heatmaps(fens, out_dir="analysis/heatmaps")` – create
+  heatmap JSON files and return them as dictionaries.
+* `compute_metrics(fen)` – compute short‑ and long‑term metrics for a
+  position.
+
+## Data formats
+
+### Heatmaps
+
+Heatmaps are written as JSON files inside ``analysis/heatmaps/``.  Each
+file contains an 8×8 matrix of integers, e.g.
+
+```json
+[[0,1,0,0,0,0,0,0],
+ [0,0,0,0,0,0,0,0],
+ ...]
+```
+
+### Metrics
+
+Metrics follow a nested JSON structure where scores are grouped into
+``short_term`` and ``long_term`` categories:
+
+```json
+{
+  "short_term": {"attacked_squares": 3, "defended_pieces": -1},
+  "long_term": {"center_control": 2, "king_safety": 0,
+                  "pawn_structure_stability": -1}
+}
+```
+
+## Example usage
+
+```python
+from utils.integration import parse_fen, generate_heatmaps, compute_metrics
+
+fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+board_state = parse_fen(fen)
+heatmaps = generate_heatmaps([fen])
+metrics = compute_metrics(fen)
+```
+
+The ``heatmaps`` dictionary maps FEN identifiers to 8×8 matrices, while
+``metrics`` contains the derived evaluation numbers for the position.

--- a/examples/integration_example.py
+++ b/examples/integration_example.py
@@ -1,0 +1,15 @@
+import json
+from utils.integration import parse_fen, generate_heatmaps, compute_metrics
+
+fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+board = parse_fen(fen)
+heatmaps = generate_heatmaps([fen])
+metrics = compute_metrics(fen)
+
+print("Board:")
+print(board)
+print("Heatmaps:")
+print(json.dumps(heatmaps, indent=2))
+print("Metrics:")
+print(json.dumps(metrics, indent=2))

--- a/utils/integration.py
+++ b/utils/integration.py
@@ -1,0 +1,71 @@
+"""Convenience wrappers for FEN parsing, heatmap generation and metrics.
+
+This module exposes a tiny API that other projects can use to interact
+with the chess analysis tools provided by this repository.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Iterable, List, Dict, Any
+
+import chess
+
+from fen_handler import fen_to_board_state
+from analysis.loader import export_fen_table
+from metrics import MetricsManager
+
+
+def parse_fen(fen: str) -> List[List[str | None]]:
+    """Return a board representation for *fen*.
+
+    The board is represented as an 8×8 list where each entry is a piece
+    name or ``None`` for empty squares.
+    """
+
+    return fen_to_board_state(fen)
+
+
+def generate_heatmaps(
+    fens: Iterable[str],
+    out_dir: str = "analysis/heatmaps",
+) -> Dict[str, List[List[int]]]:
+    """Generate heatmaps for *fens* and return them as dictionaries.
+
+    This function serialises ``fens`` into a CSV file and invokes the
+    :mod:`analysis.heatmaps.generate_heatmaps.R` script via ``Rscript``.
+    The resulting JSON heatmaps are loaded and returned as a mapping from
+    ``fen_id`` to 8×8 integer matrices.
+    """
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    csv_path = out_path / "fens.csv"
+    export_fen_table(fens, csv_path=str(csv_path))
+
+    script = Path("analysis/heatmaps/generate_heatmaps.R")
+    subprocess.run(["Rscript", str(script), str(csv_path)], check=True)
+
+    heatmaps: Dict[str, List[List[int]]] = {}
+    for json_file in out_path.glob("heatmap_*.json"):
+        with json_file.open("r", encoding="utf-8") as fh:
+            heatmaps[json_file.stem.replace("heatmap_", "")] = json.load(fh)
+    return heatmaps
+
+
+def compute_metrics(fen: str) -> Dict[str, Dict[str, Any]]:
+    """Compute short- and long-term metrics for *fen*.
+
+    The returned dictionary contains two keys, ``short_term`` and
+    ``long_term``, each mapping metric names to integer scores.
+    """
+
+    board = chess.Board(fen)
+    mgr = MetricsManager(board)
+    mgr.update_all_metrics()
+    return mgr.get_metrics()
+
+
+__all__ = ["parse_fen", "generate_heatmaps", "compute_metrics"]


### PR DESCRIPTION
## Summary
- Documented how to integrate with the repository by outlining data formats and API usage for heatmaps and metrics.
- Added `utils.integration` module providing simple functions for FEN parsing, heatmap generation, and metric computation.
- Included a runnable example script showing how external projects can call the new utilities.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9001d1d0832596b0f6fbe74c4daa