### PR TITLE
Add streaming run loader with sampling

### DIFF
--- a/docs/sampling_strategy.md
+++ b/docs/sampling_strategy.md
@@ -1,0 +1,29 @@
+# Sampling Strategy
+
+The analysis utilities can process large collections of run JSON files without
+loading every game into memory.  To keep analysis tractable while covering a
+representative set of games, sample at least **1000** games from the archive.
+
+## Random subset
+
+Use the loader's sampling options to select a random subset of runs:
+
+```bash
+python analysis/loader.py runs/ --sample-size 1000 --seed 42
+```
+
+`--sample-size` limits the number of games processed and `--seed` controls the
+random selection.  When fewer than ``sample-size`` files are available, all
+files are used.
+
+## Sliding window
+
+Omitting ``--seed`` processes files in sorted order.  Limiting the sample size
+then effectively yields a sliding window over the most recent games:
+
+```bash
+python analysis/loader.py runs/ --sample-size 1000
+```
+
+Both approaches guarantee that at least 1000 games are analysed when
+``--sample-size`` is set to ``1000`` or higher.

--- a/tests/test_stream_runs.py
+++ b/tests/test_stream_runs.py
@@ -1,0 +1,35 @@
+import json
+import os
+import tempfile
+
+from analysis.loader import aggregate_run_stats, stream_runs
+
+
+def _create_runs(tmpdir, count, moves_per_game=1):
+    sample = {
+        "moves": ["e4"] * moves_per_game,
+        "fens": ["startpos"] * moves_per_game,
+        "modules_w": ["m1"],
+        "modules_b": ["m2"],
+        "result": "1-0",
+    }
+    for i in range(count):
+        with open(os.path.join(tmpdir, f"game{i}.json"), "w", encoding="utf-8") as fh:
+            json.dump(sample, fh)
+
+
+def test_stream_runs_sampling_deterministic():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _create_runs(tmpdir, 10)
+        runs = list(stream_runs(tmpdir, sample_size=5, seed=1))
+        runs2 = list(stream_runs(tmpdir, sample_size=5, seed=1))
+        assert [r["game_id"] for r in runs] == [r["game_id"] for r in runs2]
+        assert len(runs) == 5
+
+
+def test_aggregate_run_stats():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _create_runs(tmpdir, 3, moves_per_game=2)
+        stats = aggregate_run_stats(tmpdir)
+        assert stats["games"] == 3
+        assert stats["moves"] == 6


### PR DESCRIPTION
## Summary
- Stream-process run JSON files to avoid loading all runs into memory
- Add sample-size and seed options to loader CLI
- Document strategies for sampling at least 1000 games
- Test deterministic sampling and aggregated stats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8b2f24548325baa31416a97618cc