### PR TITLE
Add heatmap binning option

### DIFF
--- a/analysis/heatmaps/generate_heatmaps.R
+++ b/analysis/heatmaps/generate_heatmaps.R
@@ -14,7 +14,9 @@ option_list <- list(
   make_option(c("-t", "--theme"), type = "character", default = "minimal",
               help = "ggplot2 theme to use (e.g., minimal, classic) [default %default]"),
   make_option(c("-r", "--resolution"), type = "integer", default = 300,
-              help = "Resolution (DPI) for output PNG files [default %default]")
+              help = "Resolution (DPI) for output PNG files [default %default]"),
+  make_option(c("-b", "--bins"), type = "integer", default = 8,
+              help = "Number of bins for heatmap grid [default %default]")
 )
 
 parser <- OptionParser(usage = "%prog [options] <moves.csv>",
@@ -31,40 +33,48 @@ opts <- args$options
 
 moves <- read.csv(input_csv, stringsAsFactors = FALSE)
 
-# Extract file (a-h) and rank (1-8) from destination square
+# Extract numeric file (1-8) and rank (1-8) from destination square
 moves <- moves %>%
-  mutate(file = substr(to, 1, 1), rank = as.integer(substr(to, 2, 2)))
-
-counts <- moves %>%
-  group_by(piece, file, rank) %>%
-  tally(name = "freq")
+  mutate(file = match(substr(to, 1, 1), letters[1:8]),
+         rank = as.integer(substr(to, 2, 2)))
 
 out_dir <- "analysis/heatmaps"
 dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
 
-pieces <- unique(counts$piece)
+pieces <- unique(moves$piece)
+
+bin_edges <- seq(0, 8, length.out = opts$bins + 1)
 
 for (p in pieces) {
-  dfp <- counts %>% filter(piece == p)
-  mat <- matrix(0, nrow = 8, ncol = 8, dimnames = list(8:1, letters[1:8]))
-  for (i in seq_len(nrow(dfp))) {
-    r <- dfp$rank[i]
-    f <- match(dfp$file[i], letters[1:8])
-    mat[r, f] <- dfp$freq[i]
+  dfp <- moves %>% filter(piece == p)
+
+  # Compute bin counts for export
+  counts <- dfp %>%
+    mutate(file_bin = cut(file, breaks = bin_edges, labels = FALSE, include.lowest = TRUE),
+           rank_bin = cut(rank, breaks = bin_edges, labels = FALSE, include.lowest = TRUE)) %>%
+    group_by(rank_bin, file_bin) %>%
+    tally(name = "freq")
+
+  mat <- matrix(0, nrow = opts$bins, ncol = opts$bins,
+                dimnames = list(opts$bins:1, letters[1:opts$bins]))
+  for (i in seq_len(nrow(counts))) {
+    r <- counts$rank_bin[i]
+    f <- counts$file_bin[i]
+    mat[r, f] <- counts$freq[i]
   }
-  csv_path <- file.path(out_dir, paste0("heatmap_", p, ".csv"))
-  json_path <- file.path(out_dir, paste0("heatmap_", p, ".json"))
+  csv_path <- file.path(out_dir, paste0("heatmap_", p, "_bins", opts$bins, ".csv"))
+  json_path <- file.path(out_dir, paste0("heatmap_", p, "_bins", opts$bins, ".json"))
   write.csv(mat, file = csv_path)
   write_json(as.data.frame(mat), path = json_path, pretty = TRUE)
 
-  plotdf <- as.data.frame(as.table(mat))
-  colnames(plotdf) <- c("rank", "file", "freq")
   theme_fun <- get(paste0("theme_", opts$theme), envir = asNamespace("ggplot2"))
-  g <- ggplot(plotdf, aes(x = file, y = rank, fill = freq)) +
-    geom_tile() +
-    scale_y_continuous(trans = "reverse") +
+  g <- ggplot(dfp, aes(x = file, y = rank)) +
+    geom_bin2d(bins = opts$bins) +
+    scale_x_continuous(breaks = 1:8, labels = letters[1:8]) +
+    scale_y_continuous(trans = "reverse", breaks = 1:8) +
     scale_fill_distiller(palette = opts$palette, direction = 1) +
     ggtitle(paste("Move frequencies for", p)) +
     theme_fun()
-  ggsave(file.path(out_dir, paste0("heatmap_", p, ".png")), g, dpi = opts$resolution)
+  ggsave(file.path(out_dir, paste0("heatmap_", p, "_bins", opts$bins, ".png")), g,
+         dpi = opts$resolution)
 }


### PR DESCRIPTION
## Summary
- allow heatmap generation script to accept a `--bins` option for grid size
- compute move frequencies with `geom_bin2d()` and export bin-aware artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af915140b483258e4bc8b36b62bfe8