### PR TITLE
Add R heatmap example to integration guide

### DIFF
--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -56,3 +56,19 @@ metrics = compute_metrics(fen)
 
 The ``heatmaps`` dictionary maps FEN identifiers to 8×8 matrices, while
 ``metrics`` contains the derived evaluation numbers for the position.
+
+### Generating heatmaps in R
+
+You can render heatmaps in R using ``ggplot2``. First convert the JSON
+matrix produced by ``generate_heatmaps`` into a data frame with columns
+``x`` and ``y``. Then plot it with:
+
+```r
+ggplot(queen_moves, aes(x, y)) +
+  geom_bin2d(bins = 8) +
+  scale_fill_gradient(low = "white", high = "red") +
+  coord_fixed()
+```
+
+Replace ``queen_moves`` with your own move data derived from the JSON
+heatmap. Output files are saved to ``analysis/heatmaps/`` by default.


### PR DESCRIPTION
## Summary
- document how to plot generated heatmaps in R using ggplot2
- note that the JSON output can be converted to an `x`/`y` data frame and that files save under `analysis/heatmaps/`

## Testing
- `pytest tests/test_random_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00e2e5b24832599d330a1d09d8b9b