### PR TITLE
Add en passant corridor threat detection

### DIFF
--- a/tests/test_treat_guard.py
+++ b/tests/test_treat_guard.py
@@ -1,0 +1,21 @@
+import chess
+
+from chess_ai.treat_guard import enemy_two_move_fork_risk
+
+
+def test_en_passant_corridor_detected():
+    board = chess.Board("4k3/8/8/8/5p1p/8/6P1/4K3 b - - 0 1")
+    risk, tag, r1, r2 = enemy_two_move_fork_risk(board, chess.WHITE)
+    assert risk
+    assert tag == "P:ep-corridor"
+    assert r1 == chess.Move.from_uci("f4f3")
+    assert r2 == chess.Move.from_uci("f3g4")
+
+
+def test_en_passant_corridor_absent():
+    board = chess.Board("4k3/8/8/8/5p2/8/6P1/4K3 b - - 0 1")
+    risk, tag, r1, r2 = enemy_two_move_fork_risk(board, chess.WHITE)
+    assert not risk
+    assert tag == ""
+    assert r1 is None and r2 is None
+


### PR DESCRIPTION
## Summary
- detect pawn corridor setups that force an en passant capture against the g-pawn
- flag en-passant corridor risks in enemy two-move fork analysis
- test corridor detection for both applicable and inapplicable scenarios

## Testing
- `pytest tests/test_treat_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00fc0a83483258c43594ab5bd23be