### PR TITLE
Add Wolfram heatmap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,16 @@ heatmaps:
 ```bash
 python -m analysis.loader runs/ --csv analysis/heatmaps/moves.csv --rds analysis/heatmaps/moves.rds
 Rscript analysis/heatmaps/generate_heatmaps.R analysis/heatmaps/moves.csv
+# or using the Wolfram Language
+wolframscript -file analysis/heatmaps/generate_heatmaps.wl \
+  --palette Reds --bins 8 --resolution 300 analysis/heatmaps/moves.csv
 ```
 
 Heatmap matrices are written as CSV and JSON files into `analysis/heatmaps/`.
+The Wolfram variant requires the Wolfram Engine and exposes the same
+`--palette`, `--bins` and `--resolution` options. From Python set
+`use_wolfram=True` when calling `utils.integration.generate_heatmaps` to use
+this script.
 
 ## Piece positions from FEN
 

--- a/analysis/heatmaps/generate_heatmaps.wl
+++ b/analysis/heatmaps/generate_heatmaps.wl
@@ -1,0 +1,60 @@
+#!/usr/bin/env wolframscript
+
+(* Generate heatmaps from a CSV table of piece moves.
+   The script mirrors the options of the R implementation and
+   writes CSV, JSON and PNG files for each piece. *)
+
+args = Rest[$ScriptCommandLine];
+opts = <|"palette" -> "Reds", "bins" -> 8, "resolution" -> 300|>;
+input = None;
+i = 1;
+While[i <= Length[args],
+  arg = args[[i]];
+  If[StringStartsQ[arg, "--"],
+    Switch[arg,
+      "--palette", i++; opts["palette"] = args[[i]],
+      "--bins", i++; opts["bins"] = ToExpression[args[[i]]],
+      "--resolution", i++; opts["resolution"] = ToExpression[args[[i]]],
+      _, Null
+    ],
+    If[input === None, input = arg]
+  ];
+  i++;
+];
+
+If[input === None,
+  Print["Usage: generate_heatmaps.wl [--palette name] [--bins n] [--resolution dpi] <moves.csv>"];
+  Exit[1]
+];
+
+moves = Import[input];
+headers = First[moves];
+rows = Rest[moves];
+records = AssociationThread[headers, #] & /@ rows;
+
+letterToNum = AssociationThread[{"a", "b", "c", "d", "e", "f", "g", "h"} -> Range[8]];
+
+grouped = GroupBy[records, #piece &];
+outDir = DirectoryName[input];
+binFun = Function[{val}, Ceiling[val*opts["bins"]/8]];
+
+Do[
+  pieceRecords = grouped[piece];
+  files = letterToNum[StringTake[#to, 1]] & /@ pieceRecords;
+  ranks = ToExpression[StringTake[#to, 2]] & /@ pieceRecords;
+  fileBins = binFun /@ files;
+  rankBins = binFun /@ ranks;
+  mat = ConstantArray[0, {opts["bins"], opts["bins"]}];
+  Do[
+    mat[[rankBins[[k]], fileBins[[k]]]]++,
+    {k, Length[fileBins]}
+  ];
+  csvPath = FileNameJoin[{outDir, "heatmap_" <> piece <> "_bins" <> ToString[opts["bins"]] <> ".csv"}];
+  jsonPath = FileNameJoin[{outDir, "heatmap_" <> piece <> "_bins" <> ToString[opts["bins"]] <> ".json"}];
+  pngPath = FileNameJoin[{outDir, "heatmap_" <> piece <> "_bins" <> ToString[opts["bins"]] <> ".png"}];
+  Export[csvPath, mat];
+  Export[jsonPath, mat, "JSON", "Compact" -> False];
+  plot = ArrayPlot[Reverse[mat], ColorFunction -> ColorData[opts["palette"]],
+    Frame -> False, ColorFunctionScaling -> True];
+  Export[pngPath, plot, ImageResolution -> opts["resolution"]];
+  , {piece, Keys[grouped]}];

--- a/tests/test_generate_heatmaps.py
+++ b/tests/test_generate_heatmaps.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 
-def test_generate_heatmaps_rscript_missing(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "use_wolfram,missing",
+    [(False, "Rscript"), (True, "wolframscript")],
+)
+def test_generate_heatmaps_script_missing(monkeypatch, tmp_path, use_wolfram, missing):
     dummy_chess = types.SimpleNamespace(Board=object)
     monkeypatch.setitem(sys.modules, "chess", dummy_chess)
 
@@ -21,6 +25,6 @@ def test_generate_heatmaps_rscript_missing(monkeypatch, tmp_path):
 
     monkeypatch.setattr(integration.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="Rscript not found; install R to generate heatmaps"):
-        integration.generate_heatmaps([], out_dir=str(tmp_path))
+    with pytest.raises(RuntimeError, match=f"{missing} not found"):
+        integration.generate_heatmaps([], out_dir=str(tmp_path), use_wolfram=use_wolfram)
 


### PR DESCRIPTION
## Summary
- add Wolfram Language heatmap generator with CSV import and ArrayPlot rendering
- allow `utils.integration.generate_heatmaps` to use Wolfram script via `use_wolfram` flag
- document Wolfram setup and invocation in heatmap README section
- test missing `wolframscript` error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1ef5bb494832597129732072adb0e