### PR TITLE
Use dotted lines for timeline separators and hover

### DIFF
--- a/ui/usage_timeline.py
+++ b/ui/usage_timeline.py
@@ -168,8 +168,11 @@ class UsageTimeline(QWidget):
                     painter.save()
                     painter.setPen(Qt.NoPen)
                     painter.fillRect(rect, QColor(0, 0, 0, 40))
+                    hover_pen = QPen(QColor(80, 80, 80), 1, Qt.DotLine)
+                    painter.setPen(hover_pen)
+                    painter.drawRect(rect)
                     painter.restore()
-                painter.setPen(QPen(QColor(200, 200, 200)))
+                painter.setPen(QPen(QColor(200, 200, 200), 1, Qt.DotLine))
                 painter.drawLine(x + seg_w, y, x + seg_w, y + lane_h)
                 painter.setPen(Qt.NoPen)
                 if self._selected == (i, is_white):


### PR DESCRIPTION
## Summary
- draw vertical separators in the usage timeline with dotted pens for better visual separation
- highlight hovered moves with a dotted outline for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f03f9cd883259b52be5ea532020b