### PR TITLE
Add usage log viewer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ python scripts/bot_usage_stats.py --runs runs/
 
 The script outputs a JSON mapping of module names to their total usage counts.
 
+## Usage log viewer
+
+Inspect the recorded usage counters without launching the full GUI viewer:
+
+```bash
+python scripts/usage_log_viewer.py
+```
+
+The script prints a table showing each path and how often it has been used.
+
 ## Move heatmaps
 
 Convert recorded run JSON files into a flat move table and generate per-piece

--- a/scripts/usage_log_viewer.py
+++ b/scripts/usage_log_viewer.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repository root and vendored packages are importable
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+VENDOR_PATH = ROOT / "vendors"
+if VENDOR_PATH.exists() and str(VENDOR_PATH) not in sys.path:
+    sys.path.insert(0, str(VENDOR_PATH))
+
+import importlib.util
+
+USAGE_LOGGER_PATH = ROOT / "utils" / "usage_logger.py"
+spec = importlib.util.spec_from_file_location("usage_logger", USAGE_LOGGER_PATH)
+usage_logger = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(usage_logger)  # type: ignore[assignment]
+read_usage = usage_logger.read_usage
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Display usage counters in a simple text table.
+
+    The counters are read from ``stats/usage_counts.json`` which tracks how
+    often various scripts or modules have been run.  The output shows each
+    entry's count along with an ASCII bar for quick comparison.
+    """
+    counts = read_usage()
+    if not counts:
+        print("No usage data found.")
+        return 0
+
+    width = max(len(path) for path in counts)
+    max_count = max(counts.values())
+    scale = 40 / max_count if max_count else 1
+
+    header = f"{'Path':<{width}} | Count | Chart"
+    print(header)
+    print("-" * len(header))
+    for path, count in sorted(counts.items(), key=lambda x: (-x[1], x[0])):
+        bar = "#" * int(count * scale)
+        print(f"{path:<{width}} | {count:>5} | {bar}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/usage_log_viewer.py` to display usage counts in a simple table
- document how to launch the usage log viewer

## Testing
- `pytest tests/test_module_usage.py -q -rs`

------
https://chatgpt.com/codex/tasks/task_e_68b46b2056208325aaa4768d0597c39d