### PR TITLE
Add containerized R test support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::testthat
-          cache-version: 1
+      - name: Build Docker image
+        run: docker build -t chess-test .
       - name: Run R tests
-        run: Rscript -e 'testthat::test_dir(".", reporter="summary")'
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace chess-test bash scripts/run_r_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
     && pip install --no-cache-dir pytest \
     && rm -rf /tmp/pip-tmp
 
+# Install R and testthat
+RUN apt-get update \
+    && apt-get install -y r-base \
+    && R -e 'install.packages("testthat", repos="https://cloud.r-project.org")' \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set the default workdir
 WORKDIR /workspace
 

--- a/scripts/run_r_tests.sh
+++ b/scripts/run_r_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+Rscript -e 'testthat::test_dir("tests/testthat", reporter="summary")'

--- a/tests/testthat/test_sanity.R
+++ b/tests/testthat/test_sanity.R
@@ -1,0 +1,3 @@
+testthat::test_that("basic math works", {
+  testthat::expect_equal(1 + 1, 2)
+})


### PR DESCRIPTION
## Summary
- install R and testthat in devcontainer
- add script and CI job to run R tests inside the container
- include a basic R test example

## Testing
- `pytest` *(fails: IndentationError in core/board.py)*
- `scripts/run_r_tests.sh` *(fails: Rscript: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5178674848325b4352dfe73cf9d04