### PR TITLE
Add Python debugger launch configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ htmlcov/
 .ipynb_checkpoints/
 
 # IDE/OS
-.vscode/
+.vscode/*
+!.vscode/launch.json
 .idea/
 .DS_Store
 Thumbs.db

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Python File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- allow the repository to track VS Code settings
- add a VS Code launch configuration for debugging Python files

## Testing
- `pytest tests/test_random_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5d03245e48325b1612efec28efe01