### PR TITLE
fix: ensure Python debugger configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Python Debugger: Python File",
-            "type": "debugpy",
+            "type": "python",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal"


### PR DESCRIPTION
## Summary
- update `.vscode/launch.json` to use the `python` debug type so VS Code recognizes the "Python Debugger: Python File" configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5edb2f3f08325924b33c0d1ca9787