### PR TITLE
Use caplog for debug assertions in bot tests

### DIFF
--- a/tests/test_aggressive_bot.py
+++ b/tests/test_aggressive_bot.py
@@ -1,20 +1,21 @@
+import logging
+
 import chess
 from chess_ai.aggressive_bot import AggressiveBot
 from utils import GameContext
 
 
-def test_capture_gain_scaled_when_behind(capfd, evaluator):
+def test_capture_gain_scaled_when_behind(caplog, evaluator):
     board = chess.Board("8/8/8/3r4/2P5/8/8/8 w - - 0 1")
     evaluator.board = board
     ctx = GameContext(material_diff=-1)
     bot = AggressiveBot(chess.WHITE, capture_gain_factor=1.5)
-    move, score = bot.choose_move(board, context=ctx, evaluator=evaluator, debug=True)
+    with caplog.at_level(logging.DEBUG):
+        move, score = bot.choose_move(board, context=ctx, evaluator=evaluator, debug=True)
     assert move == chess.Move.from_uci("c4d5")
 
     tmp = board.copy(stack=False)
     tmp.push(chess.Move.from_uci("c4d5"))
     expected = 6 + evaluator.position_score(tmp, chess.WHITE)
     assert score == expected
-
-    output = capfd.readouterr().out
-    assert "material deficit" in output
+    assert "material deficit" in caplog.text

--- a/tests/test_fortify_bot.py
+++ b/tests/test_fortify_bot.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 import chess
 
@@ -15,15 +16,15 @@ class DummyEval:
         return 0
 
 
-def test_skips_when_king_safe(capfd, context, evaluator):
+def test_skips_when_king_safe(caplog, context, evaluator):
     board = chess.Board()
     evaluator.board = board
     bot = FortifyBot(chess.WHITE)
     context.king_safety = KING_SAFETY_THRESHOLD
-    move, score = bot.choose_move(board, context=context, evaluator=evaluator, debug=True)
+    with caplog.at_level(logging.DEBUG):
+        move, score = bot.choose_move(board, context=context, evaluator=evaluator, debug=True)
     assert move is None and score == 0.0
-    out = capfd.readouterr().out
-    assert "king safety" in out
+    assert "king safety" in caplog.text
 
 
 def test_reuses_provided_evaluator(monkeypatch, context):


### PR DESCRIPTION
## Summary
- Replace capfd with caplog in AggressiveBot and FortifyBot tests
- Assert debug messages for material deficit and king safety via caplog

## Testing
- `pip install python-chess` *(fails: Could not find a version due to 403 Forbidden proxy)*
- `pytest tests/test_aggressive_bot.py tests/test_fortify_bot.py -q` *(fails: dependencies missing, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aa15b84483259c28cdab351feedc