### PR TITLE
Skip stub test when real python-chess present

### DIFF
--- a/tests/test_chess_stub.py
+++ b/tests/test_chess_stub.py
@@ -1,9 +1,20 @@
 import subprocess
 import sys
 from pathlib import Path
+import importlib.util
+
+import pytest
 
 
 def test_stub_raises_importerror_outside_pytest():
+    spec = importlib.util.find_spec("chess")
+    if spec and spec.origin:
+        vendors_dir = Path(__file__).resolve().parent.parent / "vendors"
+        chess_path = Path(spec.origin).resolve()
+        try:
+            chess_path.relative_to(vendors_dir)
+        except ValueError:
+            pytest.skip("real python-chess installed")
     code = (
         "import sys\n"
         "sys.path.append('vendors')\n"


### PR DESCRIPTION
## Summary
- Ensure the chess stub test skips when a real `python-chess` installation is detected.

## Testing
- `pytest tests/test_chess_stub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8afcfd4ec8325bbea304708caf3bc