### PR TITLE
Replace invalid FEN row in tests

### DIFF
--- a/tests/test_escape_squares.py
+++ b/tests/test_escape_squares.py
@@ -12,12 +12,12 @@ def _moves_to_squares(moves):
 
 
 def test_escape_squares_one_escape():
-    board = chess.Board("n5k1/1B42/8/P7/8/8/8/7K w - - 0 1")
+    board = chess.Board("n5k1/1B6/8/P7/8/8/8/7K w - - 0 1")
     escapes = escape_squares(board, chess.A8)
     assert _moves_to_squares(escapes) == {chess.C7}
 
 
 def test_escape_squares_two_escapes():
-    board = chess.Board("n5k1/1B42/8/8/8/8/8/7K w - - 0 1")
+    board = chess.Board("n5k1/1B6/8/8/8/8/8/7K w - - 0 1")
     escapes = escape_squares(board, chess.A8)
     assert _moves_to_squares(escapes) == {chess.B6, chess.C7}

--- a/tests/test_is_piece_mated.py
+++ b/tests/test_is_piece_mated.py
@@ -15,5 +15,5 @@ def test_is_piece_mated_detects_trapped_piece():
 
 
 def test_is_piece_mated_false_when_escape_exists():
-    board = chess.Board("n5k1/1B42/8/8/8/8/8/7K w - - 0 1")
+    board = chess.Board("n5k1/1B6/8/8/8/8/8/7K w - - 0 1")
     assert not is_piece_mated(board, chess.A8)


### PR DESCRIPTION
## Summary
- fix FEN rows using `1B6` instead of `1B42`
- ensure test positions have valid FEN formatting

## Testing
- `pytest tests/test_escape_squares.py tests/test_is_piece_mated.py` *(fails: python-chess missing)*
- `pip install python-chess` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bfd591608325b7bae850bb15d498