### PR TITLE
Handle missing robjects in eval board test

### DIFF
--- a/tests/test_r_bridge.py
+++ b/tests/test_r_bridge.py
@@ -34,6 +34,8 @@ def test_eval_board_returns_float_when_r_available():
     pytest.importorskip("rpy2")
     import chess_ai.hybrid_bot.r_bridge as rb
     importlib.reload(rb)
+    if rb.robjects is None:
+        pytest.skip("rpy2.robjects could not be loaded")
     score = rb.eval_board(chess.Board())
     assert isinstance(score, float)
 


### PR DESCRIPTION
## Summary
- Skip eval-board integration test when `rpy2.robjects` cannot be loaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba8487d6d4832582f8e6f3bd925550