### PR TITLE
Use takeFirst for QSignalSpy tests

### DIFF
--- a/tests/test_usage_timeline.py
+++ b/tests/test_usage_timeline.py
@@ -46,14 +46,16 @@ def test_usage_timeline_clicks_and_signal():
     pos_w1 = _segment_pos(widget, 1, True)
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, pos_w1)
     assert widget.last == (1, True)
-    assert spy.count() == 1 and spy[0] == [1, True]
+    assert spy.count() == 1
+    assert spy.takeFirst() == [1, True]
     spy.clear()
 
     # Click third black segment
     pos_b2 = _segment_pos(widget, 2, False)
     QTest.mouseClick(widget, Qt.LeftButton, Qt.NoModifier, pos_b2)
     assert widget.last == (2, False)
-    assert spy.count() == 1 and spy[0] == [2, False]
+    assert spy.count() == 1
+    assert spy.takeFirst() == [2, False]
     spy.clear()
 
     # Click outside any segment (right of last white segment)


### PR DESCRIPTION
## Summary
- Replace direct indexing on QSignalSpy with takeFirst
- Assert signal argument list for move clicks in usage timeline tests

## Testing
- `pytest tests/test_usage_timeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb44066e188325941bcc9b1ac58442