### PR TITLE
Handle missing R runtime in r_bridge tests

### DIFF
--- a/tests/test_r_bridge.py
+++ b/tests/test_r_bridge.py
@@ -35,7 +35,12 @@ def test_eval_board_returns_float_when_r_available():
     import chess_ai.hybrid_bot.r_bridge as rb
     importlib.reload(rb)
     if rb.robjects is None:
+        with pytest.raises(RuntimeError):
+            rb.eval_board(chess.Board())
         pytest.skip("rpy2.robjects could not be loaded")
-    score = rb.eval_board(chess.Board())
+    try:
+        score = rb.eval_board(chess.Board())
+    except RuntimeError:
+        pytest.skip("R runtime not available")
     assert isinstance(score, float)
 


### PR DESCRIPTION
## Summary
- make r_bridge tests robust to missing R runtime by expecting `RuntimeError` when robjects is unavailable and skipping when R cannot run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5452cea483258c13b5f392217515