### PR TITLE
Use caplog for debug assertions in bot tests

### DIFF
--- a/tests/test_aggressive_bot.py
+++ b/tests/test_aggressive_bot.py
@@ -16,6 +16,10 @@ def test_capture_gain_scaled_when_behind(caplog, evaluator):
 
     tmp = board.copy(stack=False)
     tmp.push(chess.Move.from_uci("c4d5"))
-    expected = 6 + evaluator.position_score(tmp, chess.WHITE)
+    expected_gain = 6
+    expected = expected_gain + evaluator.position_score(tmp, chess.WHITE)
     assert score == expected
-    assert "material deficit" in caplog.text
+    assert (
+        f"AggressiveBot: material deficit, scaled capture gain to {expected_gain:.1f}"
+        in caplog.text
+    )

--- a/tests/test_fortify_bot.py
+++ b/tests/test_fortify_bot.py
@@ -24,7 +24,10 @@ def test_skips_when_king_safe(caplog, context, evaluator):
     with caplog.at_level(logging.DEBUG):
         move, score = bot.choose_move(board, context=context, evaluator=evaluator, debug=True)
     assert move is None and score == 0.0
-    assert "king safety" in caplog.text
+    expected_msg = (
+        f"FortifyBot: king safety {context.king_safety} ≥ {KING_SAFETY_THRESHOLD} – skipping fortification"
+    )
+    assert expected_msg in caplog.text
 
 
 def test_reuses_provided_evaluator(monkeypatch, context):


### PR DESCRIPTION
## Summary
- assert AggressiveBot's material deficit message via `caplog.text`
- assert FortifyBot's king safety skip message via `caplog.text`

## Testing
- `pytest tests/test_aggressive_bot.py tests/test_fortify_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6ee740c88325b5d365318216b01f