### PR TITLE
Clarify pressure evaluation orientation

### DIFF
--- a/metrics_common.py
+++ b/metrics_common.py
@@ -106,9 +106,10 @@ def evaluate_pressure(board: chess.Board) -> int:
 
     A piece contributes its standard value to its owner's pressure score when
     it is currently attacked by the opposing side. Kings are ignored. The
-    returned score is the total pressure on Black minus the total pressure on
-    White, so a positive number indicates that Black faces more pressure than
-    White.
+    returned score is the total pressure on White minus the total pressure on
+    Black, i.e. the sum of attacked White piece values minus the sum of attacked
+    Black piece values. A positive number therefore means White's pieces are
+    under greater pressure.
     """
     piece_values = {
         chess.PAWN: 1,
@@ -122,7 +123,8 @@ def evaluate_pressure(board: chess.Board) -> int:
     for sq, piece in board.piece_map().items():
         if board.is_attacked_by(not piece.color, sq):
             pressure[piece.color] += piece_values[piece.piece_type]
-    return pressure[chess.BLACK] - pressure[chess.WHITE]
+    # White pressure minus Black pressure
+    return pressure[chess.WHITE] - pressure[chess.BLACK]
 
 
 def evaluate_synergy(board: chess.Board) -> int:

--- a/tests/test_metrics_common.py
+++ b/tests/test_metrics_common.py
@@ -12,9 +12,9 @@ def test_evaluate_pressure() -> None:
     board.set_piece_at(chess.B4, chess.Piece(chess.BISHOP, chess.BLACK))
     board.set_piece_at(chess.E1, chess.Piece(chess.KNIGHT, chess.WHITE))
     # The black queen (9) is under attack by White. The white rook (5) and
-    # knight (3) are under attack by Black. Pressure differential:
-    # 9 - (5 + 3) = 1.
-    assert evaluate_pressure(board) == 1
+    # knight (3) are under attack by Black. Pressure differential
+    # (White pressure – Black pressure): (5 + 3) - 9 = -1.
+    assert evaluate_pressure(board) == -1
 
 
 def test_evaluate_synergy() -> None:


### PR DESCRIPTION
## Summary
- flip `evaluate_pressure` to use white minus black pressure and document the formula
- correct test expectation and explanation for pressure differential

## Testing
- ⚠️ `python3 -m pytest tests/test_metrics_common.py -q` *(missing pytest)*
- ⚠️ `apt-get update` *(403 errors retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bfffb2d8a083259a22cce361e04471