### PR TITLE
Ensure mobility accounts for pawn attacks

### DIFF
--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -188,6 +188,9 @@ class Evaluator:
                     continue
 
                 move_count = move_counts.get(sq, 0)
+                # ``board.turn`` is already set to ``color`` above. This ensures
+                # :func:`chess.Board.is_attacked_by` accounts for enemy pawn
+                # attacks (including en passant) when determining capturability.
                 capturable = board.is_attacked_by(not color, sq)
                 blocked = move_count == 0
                 status = None

--- a/tests/test_mobility_score.py
+++ b/tests/test_mobility_score.py
@@ -37,6 +37,20 @@ def test_per_piece_mobility_flags():
     assert pawn_stats['capturable'] is True
 
 
+def test_diagonal_pawn_attack_sets_capturable():
+    """A pawn attacked by an enemy pawn diagonally is marked capturable."""
+    board = chess.Board()
+    board.clear()
+    board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    board.set_piece_at(chess.A2, chess.Piece(chess.PAWN, chess.WHITE))
+    board.set_piece_at(chess.B3, chess.Piece(chess.PAWN, chess.BLACK))  # attacks A2
+    board.turn = chess.BLACK  # ensure turn doesn't hide pawn attacks
+    evaluator = Evaluator(board)
+    evaluator.mobility(board)
+    pawn_stats = evaluator.mobility_stats['white']['pieces'][chess.A2]
+    assert pawn_stats['capturable'] is True
+
+
 def test_king_status_checkmate_and_stalemate():
     # Checkmate scenario: black king on h8 is in check with no escape squares
     mate = chess.Board("7k/6Q1/6K1/8/8/8/8/8 w - - 0 1")


### PR DESCRIPTION
## Summary
- Clarify that `mobility` checks attacks after setting `board.turn`, so enemy pawn and en passant threats are considered
- Add regression test for diagonally attacked pawns being marked as `capturable`

## Testing
- `pytest tests/test_mobility_score.py -q` *(fails: python-chess not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68c002e27d5c8325ba61352f6452fbea