### PR TITLE
Prioritize checkmate over stalemate in mobility evaluation

### DIFF
--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -196,8 +196,11 @@ class Evaluator:
                 status = None
 
                 if piece.piece_type == chess.KING:
-                    if board.is_checkmate():
-                        status = "checkmated"
+                    if board.is_check():
+                        if board.is_checkmate():
+                            status = "checkmated"
+                        else:
+                            status = "blocked" if blocked else "mobile"
                     elif board.is_stalemate():
                         status = "stalemated"
                     else:

--- a/tests/test_mobility_score.py
+++ b/tests/test_mobility_score.py
@@ -67,3 +67,14 @@ def test_king_status_checkmate_and_stalemate():
     ksq = stale.king(chess.BLACK)
     status = evaluator.mobility_stats['black']['pieces'][ksq]['status']
     assert status == 'stalemated'
+
+
+def test_king_status_forced_checkmate_position():
+    """Ensure a forced checkmate is recognised over stalemate."""
+    # Fool's Mate checkmate: white king is checkmated on move 2...Qh4#
+    board = chess.Board("rnb1kbnr/pppp1ppp/8/4p3/4P2q/5P2/PPPP2PP/RNBQKBNR w KQkq - 0 3")
+    evaluator = Evaluator(board)
+    evaluator.mobility(board)
+    ksq = board.king(chess.WHITE)
+    status = evaluator.mobility_stats['white']['pieces'][ksq]['status']
+    assert status == 'checkmated'


### PR DESCRIPTION
## Summary
- Ensure `Evaluator.mobility` checks for `board.is_check()` before `board.is_stalemate` so checkmate status is detected first.
- Add regression test using Fool's Mate to verify checkmate recognition.

## Testing
- `pytest tests/test_mobility_score.py` *(fails: python-chess not installed, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c026a67644832596eadaf94785abd1