### PR TITLE
Improve TrapBot scoring and tests

### DIFF
--- a/chess_ai/trap_bot.py
+++ b/chess_ai/trap_bot.py
@@ -46,6 +46,10 @@ class TrapBot:
             after_eval.mobility(tmp)
             after_stats = after_eval.mobility_stats[self._opponent_label()]["pieces"]
 
+            # Deeper squares (further into enemy territory) are preferred.
+            rank = chess.square_rank(mv.to_square)
+            depth = rank + 1 if self.color == chess.WHITE else 8 - rank
+
             # Compare mobility for each opponent piece. ``move_drop`` tracks the
             # largest reduction (which may be negative if all candidate moves
             # increase the opponent's mobility). Starting at ``-inf`` ensures we
@@ -74,8 +78,13 @@ class TrapBot:
                             )
                             tmp.pop()
                         drop = pre_mob - max_mob
-                if drop > move_drop:
-                    move_drop = drop
+
+                # Weight the drop by the piece's initial mobility and how deep
+                # the trap lies to prioritise high-mobility targets and deeper
+                # incursions.
+                weighted_drop = drop * pre_mob * depth
+                if weighted_drop > move_drop:
+                    move_drop = weighted_drop
 
             if move_drop > best_drop:
                 best_drop = move_drop

--- a/tests/test_trap_bot.py
+++ b/tests/test_trap_bot.py
@@ -7,13 +7,11 @@ if not hasattr(chess, 'Board'):
 from chess_ai.trap_bot import TrapBot
 
 
-def test_trapbot_prefers_trapping_knight():
-    board = chess.Board('3nk3/3p4/8/8/8/8/8/3QK3 w - - 0 1')
+def test_trapbot_prefers_deeper_trap():
+    board = chess.Board('3nk3/8/8/8/8/8/8/3QK3 w - - 0 1')
     bot = TrapBot(chess.WHITE)
     move, _ = bot.choose_move(board)
-    # The pawn on d7 shields the knight, so capturing it limits the knight's
-    # options while also checking the king.
-    assert move == chess.Move.from_uci('d1d7')
+    assert move == chess.Move.from_uci('d1d8')
 
 
 def test_trapbot_targets_more_mobile_piece():


### PR DESCRIPTION
## Summary
- weight TrapBot mobility reduction by target mobility and depth to favor deeper traps on active pieces
- update tests to check for deeper trapping and high mobility targets

## Testing
- `pytest tests/test_trap_bot.py` *(fails: python-chess missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d3601ca483258c739210073b241b