### PR TITLE
Allow configuring heatmap output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ wolframscript -file analysis/heatmaps/generate_heatmaps.wl \
   --palette Reds --bins 8 --resolution 300 analysis/heatmaps/moves.csv
 ```
 
-Heatmap matrices are written as CSV and JSON files into `analysis/heatmaps/`.
+Heatmap matrices are written as CSV and JSON files into the directory containing
+`moves.csv` (such as `analysis/heatmaps/` in this example).
 The Wolfram variant requires the Wolfram Engine and exposes the same
 `--palette`, `--bins` and `--resolution` options. From Python set
 `use_wolfram=True` when calling `utils.integration.generate_heatmaps` to use

--- a/analysis/heatmaps/generate_heatmaps.R
+++ b/analysis/heatmaps/generate_heatmaps.R
@@ -16,7 +16,9 @@ option_list <- list(
   make_option(c("-r", "--resolution"), type = "integer", default = 300,
               help = "Resolution (DPI) for output PNG files [default %default]"),
   make_option(c("-b", "--bins"), type = "integer", default = 8,
-              help = "Number of bins for heatmap grid [default %default]")
+              help = "Number of bins for heatmap grid [default %default]"),
+  make_option(c("-o", "--outdir"), type = "character", default = NULL,
+              help = "Output directory for heatmap files [default directory of moves.csv]")
 )
 
 parser <- OptionParser(usage = "%prog [options] <moves.csv>",
@@ -31,15 +33,15 @@ if (length(args$args) < 1) {
 input_csv <- args$args[1]
 opts <- args$options
 
+out_dir <- if (is.null(opts$outdir)) dirname(input_csv) else opts$outdir
+dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+
 moves <- read.csv(input_csv, stringsAsFactors = FALSE)
 
 # Extract numeric file (1-8) and rank (1-8) from destination square
 moves <- moves %>%
   mutate(file = match(substr(to, 1, 1), letters[1:8]),
          rank = as.integer(substr(to, 2, 2)))
-
-out_dir <- "analysis/heatmaps"
-dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
 
 pieces <- unique(moves$piece)
 

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -20,8 +20,9 @@ from utils.integration import parse_fen, generate_heatmaps, compute_metrics
 
 ### Heatmaps
 
-Heatmaps are written as JSON files inside ``analysis/heatmaps/``.  Each
-file contains an 8×8 matrix of integers, e.g.
+Heatmaps are written as JSON files inside the specified output directory
+(``analysis/heatmaps/`` by default).  Each file contains an 8×8 matrix of
+integers, e.g.
 
 ```json
 [[0,1,0,0,0,0,0,0],
@@ -71,4 +72,5 @@ ggplot(queen_moves, aes(x, y)) +
 ```
 
 Replace ``queen_moves`` with your own move data derived from the JSON
-heatmap. Output files are saved to ``analysis/heatmaps/`` by default.
+heatmap. Output files are saved alongside the CSV input or to the directory
+given via ``--outdir`` (``analysis/heatmaps/`` by default).

--- a/docs/ui_overlays.md
+++ b/docs/ui_overlays.md
@@ -3,10 +3,10 @@
 The viewer can render additional overlays on top of board cells using
 `DrawerManager`.  It now understands three sources of analysis data:
 
-* **Heatmaps** – JSON files in `analysis/heatmaps/` containing 8×8
-  matrices of numbers in the range 0–1.  Each value is rendered as a
-  translucent square with a colour gradient from green (`0.0`) to red
-  (`1.0`).
+* **Heatmaps** – JSON files in the heatmap output directory (e.g.
+  `analysis/heatmaps/`) containing 8×8 matrices of numbers in the range
+  0–1.  Each value is rendered as a translucent square with a colour
+  gradient from green (`0.0`) to red (`1.0`).
 * **Agent metrics** – key/value pairs stored in
   `analysis/agent_metrics.json`.  The file is loaded on start and the
   data is available through `DrawerManager.agent_metrics` for debugging
@@ -70,8 +70,8 @@ Generate heatmaps by passing the resulting CSV to the R script:
 Rscript analysis/heatmaps/generate_heatmaps.R analysis/heatmaps/fens.csv
 ```
 
-The heatmaps are written back into `analysis/heatmaps/` and can then be
-displayed by the viewer.
+The heatmaps are written back into the same directory as `fens.csv` (or
+as specified via `--outdir`) and can then be displayed by the viewer.
 
 ### Customising style
 
@@ -89,6 +89,8 @@ Rscript analysis/heatmaps/generate_heatmaps.R \
 * `--theme` – ggplot2 theme function such as `minimal` or `classic`
   (default `minimal`).
 * `--resolution` – output image resolution in DPI (default `300`).
+* `--outdir` – directory for generated heatmap files (defaults to the
+  directory of the moves CSV).
 
 Run the script with `--help` to see all available options and defaults.
 


### PR DESCRIPTION
## Summary
- Add `--outdir` option to `analysis/heatmaps/generate_heatmaps.R`
- Default heatmap output directory to the location of the input CSV
- Document the new behavior and option in README and guides

## Testing
- `pytest tests/test_generate_heatmaps.py tests/integration/test_full_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf87606c8325928ba03dec784861