### PR TITLE
Cache attack counts in attacked_squares_metrics

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -44,10 +44,13 @@ def attacked_squares_metrics(board: chess.Board) -> dict:
                 total += 1
         return total
 
+    white_attacks = count_attacks(chess.WHITE)
+    black_attacks = count_attacks(chess.BLACK)
+
     return {
-        "white_attacks": count_attacks(chess.WHITE),
-        "black_attacks": count_attacks(chess.BLACK),
-        "delta_attacks": count_attacks(chess.WHITE) - count_attacks(chess.BLACK),
+        "white_attacks": white_attacks,
+        "black_attacks": black_attacks,
+        "delta_attacks": white_attacks - black_attacks,
     }
 
 def evaluate(board: chess.Board) -> tuple[int, dict]:


### PR DESCRIPTION
## Summary
- compute the white and black attack counts once in `attacked_squares_metrics`
- reuse the cached values to fill the metrics dictionary and compute `delta_attacks`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a299c6d48325b80c3f855f47de93