### PR TITLE
Preserve board state in mobility score

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -26,12 +26,13 @@ def mobility_score(board: chess.Board) -> int:
         return 0
 
     # Порахуємо к-ть легальних ходів для кожної сторони, не змінюючи позицію.
-    turn = board.turn
-    board.turn = chess.WHITE
-    white_moves = sum(1 for _ in board.legal_moves)
-    board.turn = chess.BLACK
-    black_moves = sum(1 for _ in board.legal_moves)
-    board.turn = turn
+    white_board = board.copy(stack=False)
+    white_board.turn = chess.WHITE
+    white_moves = sum(1 for _ in white_board.legal_moves)
+
+    black_board = board.copy(stack=False)
+    black_board.turn = chess.BLACK
+    black_moves = sum(1 for _ in black_board.legal_moves)
 
     return (white_moves - black_moves) * 2  # невелика вага
 

--- a/tests/test_evaluation_mobility_state.py
+++ b/tests/test_evaluation_mobility_state.py
@@ -1,0 +1,40 @@
+import chess
+
+from evaluation import mobility_score
+
+
+def snapshot_board_state(board: chess.Board) -> dict:
+    """Capture key elements of the board state for comparison."""
+    return {
+        "fen": board.fen(),
+        "turn": board.turn,
+        "castling_rights": board.castling_rights,
+        "ep_square": board.ep_square,
+        "halfmove_clock": board.halfmove_clock,
+        "fullmove_number": board.fullmove_number,
+        "has_legal_en_passant": board.has_legal_en_passant(),
+    }
+
+
+def test_mobility_score_preserves_castling_rights():
+    board = chess.Board("r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 5 17")
+    before = snapshot_board_state(board)
+
+    mobility_score(board)
+
+    after = snapshot_board_state(board)
+    assert after == before, "Board state changed after mobility_score with castling rights"
+
+
+def test_mobility_score_preserves_en_passant_state():
+    board = chess.Board()
+    board.push_san("e4")
+    board.push_san("d5")
+    board.push_san("exd5")
+    board.push_san("c5")
+    before = snapshot_board_state(board)
+
+    mobility_score(board)
+
+    after = snapshot_board_state(board)
+    assert after == before, "Board state changed after mobility_score with en passant rights"


### PR DESCRIPTION
## Summary
- count legal moves on board copies to avoid mutating the original state
- add regression tests ensuring castling and en passant data survive mobility scoring

## Testing
- pytest tests/test_evaluation_mobility_state.py -rs

------
https://chatgpt.com/codex/tasks/task_e_68ca98d318dc8325b09279346403fbfa