### PR TITLE
Add helper to generate heatmaps from winning PGN games

### DIFF
--- a/analysis/generate_heatmaps_from_wins.py
+++ b/analysis/generate_heatmaps_from_wins.py
@@ -1,0 +1,46 @@
+"""Generate heatmaps from winning games in a PGN file."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .pgn_loader import stream_pgn_games
+from utils.integration import generate_heatmaps
+
+
+_WIN_RESULTS = {"1-0", "0-1"}
+
+
+def generate_heatmaps_from_wins(
+    path: str,
+    *,
+    out_dir: str = "analysis/heatmaps",
+    use_wolfram: bool = False,
+):
+    """Generate heatmaps for positions taken from decisive games.
+
+    Parameters
+    ----------
+    path:
+        Path to a PGN file.
+    out_dir:
+        Directory where the generated heatmaps should be written.  This is
+        forwarded to :func:`utils.integration.generate_heatmaps`.
+    use_wolfram:
+        Whether to use the Wolfram implementation instead of the default R
+        script when generating heatmaps.
+
+    Returns
+    -------
+    Dict[str, List[List[int]]]
+        The heatmaps produced by :func:`utils.integration.generate_heatmaps`.
+    """
+
+    winning_fens: List[str] = []
+    for game in stream_pgn_games(path):
+        metadata = game.get("metadata", {})
+        result = metadata.get("Result")
+        if result in _WIN_RESULTS:
+            winning_fens.extend(game.get("fens", []))
+
+    return generate_heatmaps(winning_fens, out_dir=out_dir, use_wolfram=use_wolfram)

--- a/tests/test_generate_heatmaps_from_wins.py
+++ b/tests/test_generate_heatmaps_from_wins.py
@@ -1,0 +1,67 @@
+from analysis.generate_heatmaps_from_wins import generate_heatmaps_from_wins
+from analysis.pgn_loader import stream_pgn_games
+
+
+def test_generate_heatmaps_from_wins_filters_results(monkeypatch, tmp_path):
+    pgn_text = """
+[Event "WinGame"]
+[Site "?"]
+[Date "2024.01.01"]
+[Round "1"]
+[White "White A"]
+[Black "Black A"]
+[Result "1-0"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 1-0
+
+[Event "DrawGame"]
+[Site "?"]
+[Date "2024.01.02"]
+[Round "1"]
+[White "White B"]
+[Black "Black B"]
+[Result "1/2-1/2"]
+
+1. d4 d5 2. c4 c6 1/2-1/2
+
+[Event "LoseGame"]
+[Site "?"]
+[Date "2024.01.03"]
+[Round "1"]
+[White "White C"]
+[Black "Black C"]
+[Result "0-1"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 0-1
+"""
+    pgn_path = tmp_path / "games.pgn"
+    pgn_path.write_text(pgn_text.strip() + "\n", encoding="utf-8")
+
+    captured = {}
+
+    def fake_generate_heatmaps(fens, *, out_dir, use_wolfram):
+        captured["fens"] = list(fens)
+        captured["out_dir"] = out_dir
+        captured["use_wolfram"] = use_wolfram
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        "analysis.generate_heatmaps_from_wins.generate_heatmaps",
+        fake_generate_heatmaps,
+    )
+
+    result = generate_heatmaps_from_wins(
+        str(pgn_path), out_dir="custom", use_wolfram=True
+    )
+    assert result == {"status": "ok"}
+
+    winning_games = [
+        game
+        for game in stream_pgn_games(str(pgn_path))
+        if game["metadata"].get("Result") in {"1-0", "0-1"}
+    ]
+    expected_fens = [fen for game in winning_games for fen in game["fens"]]
+
+    assert captured["fens"] == expected_fens
+    assert captured["out_dir"] == "custom"
+    assert captured["use_wolfram"] is True


### PR DESCRIPTION
## Summary
- add a helper that filters PGN games by decisive results before generating heatmaps
- add a regression test that ensures only winning games contribute positions

## Testing
- pytest tests/test_generate_heatmaps_from_wins.py

------
https://chatgpt.com/codex/tasks/task_e_68caa757507883259d4c3dfffe8876fb