### PR TITLE
Refine annotated board layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # main.py
 import textwrap
+from itertools import zip_longest
 from typing import List, Sequence
 
 import chess
@@ -15,6 +16,7 @@ def annotated_board(
     unicode: bool = False,
     separator: str = "  │  ",
     info_width: int = 56,
+    side_by_side: bool = True,
 ) -> str:
     """Return a board diagram with a side panel of supplementary data."""
 
@@ -58,12 +60,16 @@ def annotated_board(
     if not any(line.strip() for line in wrapped_info):
         return diagram_text
 
-    total_lines = max(len(board_lines), len(wrapped_info))
-    board_lines.extend([" " * board_width] * (total_lines - len(board_lines)))
-    wrapped_info.extend([""] * (total_lines - len(wrapped_info)))
+    if not side_by_side:
+        info_text = "\n".join(wrapped_info).rstrip()
+        if not info_text:
+            return diagram_text
+        if not diagram_text:
+            return info_text
+        return f"{diagram_text}\n\n{info_text}"
 
     combined: List[str] = []
-    for board_line, info in zip(board_lines, wrapped_info):
+    for board_line, info in zip_longest(board_lines, wrapped_info, fillvalue=""):
         left = board_line.ljust(board_width)
         combined.append(f"{left}{separator}{info}".rstrip())
 

--- a/scripts/run_replay_cli.py
+++ b/scripts/run_replay_cli.py
@@ -163,7 +163,7 @@ def _display_position(
     info_lines.append(f"To move: {'White' if board.turn == chess.WHITE else 'Black'}")
     info_lines.append(f"FEN: {board.fen()}")
 
-    diagram = annotated_board(board, info_lines, unicode=unicode)
+    diagram = annotated_board(board, info_lines, unicode=unicode, side_by_side=True)
     print(diagram)
 
 


### PR DESCRIPTION
## Summary
- add a side-by-side layout toggle to `annotated_board`, aligning board and metadata columns with `zip_longest`
- update the replay CLI to request the side-by-side rendering

## Testing
- python -m compileall main.py scripts/run_replay_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cab003b1fc83258ae2a6ae3af888ac