### PR TITLE
Add heatmap set switching to DrawerManager

### DIFF
--- a/tests/test_drawer_manager_heatmaps.py
+++ b/tests/test_drawer_manager_heatmaps.py
@@ -1,0 +1,30 @@
+import pytest
+
+chess = pytest.importorskip("chess")
+
+from ui.drawer_manager import DrawerManager
+
+
+def test_set_heatmap_set_updates_overlays_and_piece():
+    manager = DrawerManager()
+    manager.heatmap_sets = {
+        "default": {"pawn": [[0.0 for _ in range(8)] for _ in range(8)]},
+        "aggressive": {"pawn": [[1.0 for _ in range(8)] for _ in range(8)]},
+    }
+    assert manager.list_heatmap_sets() == ["aggressive", "default"]
+
+    manager.active_heatmap_set = "default"
+    manager.heatmaps = manager.heatmap_sets["default"]
+    manager.active_heatmap_piece = "pawn"
+
+    manager.collect_overlays({}, chess.Board())
+    before = manager.get_cell_overlays(0, 0)
+    assert before and before[0][0] == "gradient"
+
+    manager.set_heatmap_set("aggressive")
+
+    after = manager.get_cell_overlays(0, 0)
+    assert manager.active_heatmap_set == "aggressive"
+    assert manager.active_heatmap_piece == "pawn"
+    assert after and after[0][0] == "gradient"
+    assert after[0][1] != before[0][1]

--- a/tests/test_viewer_heatmaps.py
+++ b/tests/test_viewer_heatmaps.py
@@ -25,7 +25,10 @@ def test_chess_viewer_applies_heatmap_overlay(tmp_path, monkeypatch):
         for path in heatmap_dir.glob("*.json"):
             with path.open("r", encoding="utf-8") as fh:
                 loaded[path.stem] = json.load(fh)
-        return loaded
+        self.heatmap_sets = {"default": loaded}
+        self.active_heatmap_set = "default"
+        self.heatmaps = loaded
+        self.active_heatmap_piece = next(iter(loaded), None)
 
     monkeypatch.setattr(DrawerManager, "_load_heatmaps", fake_load_heatmaps)
 


### PR DESCRIPTION
## Summary
- load heatmaps grouped by set names and track the active selection
- expose helpers to switch heatmap sets and refresh gradient overlays
- update viewer heatmap fixture and add coverage for overlay refresh

## Testing
- pytest tests/test_drawer_manager_heatmaps.py tests/test_viewer_heatmaps.py *(skipped: missing optional GUI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cac8fb937483259d571c84966da202