### PR TITLE
Define metric evaluator abstract base class

### DIFF
--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -19,6 +19,7 @@ if str(VENDOR_PATH) not in sys.path:
     sys.path.append(str(VENDOR_PATH))
 
 import chess
+from .base_evaluator import MetricEvaluator
 
 from metrics_common import (
     count_attacked_squares as _count_attacked_squares,
@@ -70,5 +71,5 @@ class MetricsManager:
         return self.metrics
 
 
-__all__ = ["MetricsManager"]
+__all__ = ["MetricsManager", "MetricEvaluator"]
 

--- a/metrics/base_evaluator.py
+++ b/metrics/base_evaluator.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import chess
+
+
+class MetricEvaluator(ABC):
+    """Abstract base for lightweight board metric evaluators.
+
+    Subclasses implement :meth:`evaluate` to compute one or more metric values
+    for the provided :class:`chess.Board` state.
+    """
+
+    @abstractmethod
+    def evaluate(self, board: chess.Board) -> Any:
+        """Compute and return metric(s) for ``board``.
+
+        Parameters
+        ----------
+        board:
+            The board position to evaluate.
+
+        Returns
+        -------
+        Any
+            A metric value or a structure of values, defined by subclasses.
+        """
+        raise NotImplementedError
+
+
+__all__ = ["MetricEvaluator"]


### PR DESCRIPTION
Define `MetricEvaluator` abstract base class to standardize metric evaluation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab7ecb23-a2e0-4047-b63b-c6a4289332bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab7ecb23-a2e0-4047-b63b-c6a4289332bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

