### PR TITLE
Debug pyside viewer json error

### DIFF
--- a/stats/usage_counts.json
+++ b/stats/usage_counts.json
@@ -1,0 +1,1 @@
+{"/workspace/pyside_viewer.py": 1}


### PR DESCRIPTION
Add `stats/usage_counts.json` to record usage metrics for `pyside_viewer.py`.

This file was generated during the investigation of a user-reported error related to the PySide viewer. While the root cause of the user's issue was identified as an external IDE configuration, this file represents internal tracking data produced during the debugging process.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d6ebc59-7e7c-4bd4-8272-8a2d9c4253b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d6ebc59-7e7c-4bd4-8272-8a2d9c4253b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

