### PR TITLE
Highlight two red squares with less transparency

### DIFF
--- a/ui/cell.py
+++ b/ui/cell.py
@@ -74,7 +74,9 @@ class Cell(QLabel):
             elif overlay_type == "king_attacked":
                 painter.setBrush(QColor("red"))
                 painter.setPen(Qt.NoPen)
+                painter.setOpacity(0.6)  # Reduce transparency from full opacity to 60%
                 painter.drawEllipse(int(4 * self.scale), int(20 * self.scale), int(13 * self.scale), int(13 * self.scale))
+                painter.setOpacity(1.0)  # Reset opacity for other drawings
             elif overlay_type == "rook_defended":
                 painter.setBrush(QColor("blue"))
                 painter.setPen(Qt.NoPen)


### PR DESCRIPTION
Reduce the transparency of "king_attacked" overlays to make them less visually prominent.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8bbc659-a63e-4912-ae2d-d39cb3718fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8bbc659-a63e-4912-ae2d-d39cb3718fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

