### PR TITLE
Add analysis and run files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ runs/20251005_234748_852173.json
 runs/20251005_234804_261736.json
 runs/20251005_234819_487123.json
 runs/20251005_234854_706995.json
+
+# Ignore entire data directories
+analysis/heatmaps/
+heatmaps/
+runs/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,20 @@ Thumbs.db
 *.qm
 
 stats/usage_counts.json
+
+# Analysis outputs
+analysis/heatmaps/default/fens.csv
+
+# Heatmaps (bins8)
+heatmaps/heatmap_B_bins8.json
+heatmaps/heatmap_K_bins8.json
+heatmaps/heatmap_N_bins8.json
+heatmaps/heatmap_P_bins8.json
+heatmaps/heatmap_Q_bins8.json
+heatmaps/heatmap_R_bins8.json
+
+# Run logs
+runs/20251005_234748_852173.json
+runs/20251005_234804_261736.json
+runs/20251005_234819_487123.json
+runs/20251005_234854_706995.json


### PR DESCRIPTION
Add specific generated analysis, heatmap, and run files to `.gitignore` to prevent them from being committed.

---
<a href="https://cursor.com/background-agent?bcId=bc-265c9da3-486c-4dac-bc7c-dd95b50cb6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-265c9da3-486c-4dac-bc7c-dd95b50cb6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

