### PR TITLE
Fix missing chess ai module

### DIFF
--- a/scripts/arena_vs_stockfish.py
+++ b/scripts/arena_vs_stockfish.py
@@ -17,6 +17,12 @@ from typing import Tuple, List
 
 import chess
 
+# Ensure project root is on sys.path when running via absolute script path
+import sys
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from chess_ai.bot_agent import make_agent, get_agent_names
 
 


### PR DESCRIPTION
Add `sys.path` shim to `arena_vs_stockfish.py` to resolve `ModuleNotFoundError` when run via absolute path.

When `scripts/arena_vs_stockfish.py` was executed using its absolute path, Python did not automatically include the project's root directory (`chess/`) in `sys.path`, leading to `ModuleNotFoundError` for `chess_ai` imports. This change explicitly adds the project root to `sys.path` if it's not already present, ensuring imports work correctly regardless of how the script is invoked.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c09017a-1b3f-4812-9005-88bedc68c086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c09017a-1b3f-4812-9005-88bedc68c086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

