### PR TITLE
Make cell highlights less transparent

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
     }
     .white { background-color: #eee; }
     .black { background-color: #999; }
-    .cell.highlight { background-color: #ffcc00 !important; }
+    /* Greener, fully opaque highlight for cells */
+    .cell.highlight { background-color: #2ecc71 !important; }
     .metrics-section {
       margin-bottom: 20px;
     }

--- a/ui/cell.py
+++ b/ui/cell.py
@@ -28,7 +28,11 @@ class Cell(QLabel):
 
     def set_highlight(self, active):
         palette = self.palette()
-        palette.setColor(QPalette.Window, QColor("#ffcc00") if active else self.base_color)
+        # Use a greener highlight with higher opacity (less transparent)
+        palette.setColor(
+            QPalette.Window,
+            QColor(46, 204, 113) if active else self.base_color,  # #2ecc71, fully opaque
+        )
         palette.setColor(QPalette.WindowText, QColor("red") if active else QColor("black"))
         self.setPalette(palette)
 


### PR DESCRIPTION
Update cell highlights to be green and fully opaque in both the PySide UI and web demo.

---
<a href="https://cursor.com/background-agent?bcId=bc-18d134e9-0521-4f66-9f3a-5845a39a190b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18d134e9-0521-4f66-9f3a-5845a39a190b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

